### PR TITLE
feat: upgrade sqlalchmey-tidb to support tidb v7.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,26 +36,6 @@ jobs:
           entrypoint: ''
           args: |
             bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py38"
-  test_py37_tidb_v4014:
-    name: test_py37_tidb_v4.0.14
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://hawkingrei/tind:v4.0.14
-        name: __all__
-        with:
-          args: |
-            bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py37"
-  test_py36_tidb_v4014:
-    name: test_py36_tidb_v4.0.14
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://hawkingrei/tind:v4.0.14
-        name: __all__
-        with:
-          args: |
-            bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py36"
   test_py39_tidb_v511:
     name: test_py39_tidb_v5.1.1
     runs-on: ubuntu-latest
@@ -77,26 +57,6 @@ jobs:
           entrypoint: ''
           args: |
             bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py38"
-  test_py37_tidb_v511:
-    name: test_py37_tidb_v5.1.1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://hawkingrei/tind:v5.1.1
-        name: __all__
-        with:
-          args: |
-            bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py37"
-  test_py36_tidb_v511:
-    name: test_py36_tidb_v5.1.1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://hawkingrei/tind:v5.1.1
-        name: __all__
-        with:
-          args: |
-            bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py36"
   test_py39_tidb_v521:
     name: test_py39_tidb_v5.2.1
     runs-on: ubuntu-latest
@@ -118,26 +78,6 @@ jobs:
           entrypoint: ''
           args: |
             bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py38"
-  test_py37_tidb_v521:
-    name: test_py37_tidb_v5.2.1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://hawkingrei/tind:v5.2.1
-        name: __all__
-        with:
-          args: |
-            bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py37"
-  test_py36_tidb_v521:
-    name: test_py36_tidb_v5.2.1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: docker://hawkingrei/tind:v5.2.1
-        name: __all__
-        with:
-          args: |
-            bash -c "service supervisor start && sleep 10s && mycli -P 4000  -h 127.0.0.1  -u root --execute='create database test_sqlalchemy;create database test_schema;'  && tox -e py36"
   test_py39_tidb_v503:
     name: test_py39_tidb_v5.0.3
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ tox
 
 ## Known issues
 
-- TiDB does not support FOREIGN KEY constraints([#18209](https://github.com/pingcap/tidb/issues/18209)).
-- TiDB does not support SAVEPOINT([#6840](https://github.com/pingcap/tidb/issues/6840)).
+- TiDB does not support FOREIGN KEY constraints until v6.6.0([#18209](https://github.com/pingcap/tidb/issues/18209)).
+- TiDB does not support SAVEPOINT until v6.2.0([#6840](https://github.com/pingcap/tidb/issues/6840)).

--- a/sqlalchemy_tidb/base.py
+++ b/sqlalchemy_tidb/base.py
@@ -115,14 +115,16 @@ class TiDBDialect(MySQLDialect):
     def do_rollback_to_savepoint(self, connection, name):
         if self.tidb_version < (6, 2, 0):
             return
-        return super(TiDBDialect, self).do_rollback_to_savepoint(connection, name)
+        return super(TiDBDialect, self).do_rollback_to_savepoint(
+            connection, name)
 
     def do_release_savepoint(self, connection, name):
         if self.tidb_version < (6, 2, 0):
             return
         return super(TiDBDialect, self).do_release_savepoint(connection, name)
 
-    # TiDB uses a two-phase commit internally, but this is not exposed via an SQL interface
+    # TiDB uses a two-phase commit internally,
+    # but this is not exposed via an SQL interface
     def do_begin_twophase(self, connection, xid):
         pass
 

--- a/sqlalchemy_tidb/provision.py
+++ b/sqlalchemy_tidb/provision.py
@@ -15,6 +15,7 @@ from sqlalchemy.testing.provision import configure_follower
 from sqlalchemy.testing.provision import create_db
 from sqlalchemy.testing.provision import drop_db
 from sqlalchemy.testing.provision import generate_driver_url
+from sqlalchemy.testing.provision import temp_table_keyword_args
 
 
 @generate_driver_url.for_db("tidb")
@@ -76,3 +77,8 @@ def _tidb_drop_db(cfg, eng, ident):
         conn.exec_driver_sql("DROP DATABASE %s_test_schema" % ident)
         conn.exec_driver_sql("DROP DATABASE %s_test_schema_2" % ident)
         conn.exec_driver_sql("DROP DATABASE %s" % ident)
+
+
+@temp_table_keyword_args.for_db("tidb")
+def _mysql_temp_table_keyword_args(cfg, eng):
+    return {"prefixes": ["TEMPORARY"]}

--- a/sqlalchemy_tidb/requirements.py
+++ b/sqlalchemy_tidb/requirements.py
@@ -10,9 +10,9 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from sqlalchemy.testing import exclusions
 from alembic.testing.requirements \
     import SuiteRequirements as SuiteRequirementsAlembic
-from sqlalchemy.testing import exclusions, fails_if, only_if
 from sqlalchemy.testing.requirements \
     import SuiteRequirements as SuiteRequirementsSQLA
 
@@ -74,27 +74,15 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
         lambda config: config.db.dialect.tidb_version < (6, 6, 0),
         'versions before 6.6.0 do not support foreign key reflection',
     )
-    foreign_key_constraint_reflection = exclusions.skip_if(
-        lambda config: config.db.dialect.tidb_version < (6, 6, 0),
-        'versions before 6.6.0 do not support foreign key reflection',
-    )
-    self_referential_foreign_keys = exclusions.skip_if(
-        lambda config: config.db.dialect.tidb_version < (6, 6, 0),
-        'versions before 6.6.0 do not support foreign key reflection',
-    )
+    foreign_key_constraint_reflection = foreign_keys
+    self_referential_foreign_keys = foreign_keys
 
     savepoints = exclusions.skip_if(
         lambda config: config.db.dialect.tidb_version < (6, 2, 0),
         'versions before 6.2.0 do not support savepoints',
     )
-    savepoints_w_release = exclusions.skip_if(
-        lambda config: config.db.dialect.tidb_version < (6, 2, 0),
-        'versions before 6.2.0 do not support savepoints',
-    )
-    compat_savepoints = exclusions.skip_if(
-        lambda config: config.db.dialect.tidb_version < (6, 2, 0),
-        'versions before 6.2.0 do not support savepoints',
-    )
+    savepoints_w_release = savepoints
+    compat_savepoints = savepoints
 
     updateable_autoincrement_pks = exclusions.open()
 
@@ -108,7 +96,7 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
             )
             return not row or "STRICT_TRANS_TABLES" not in row[1]
 
-        return only_if(check)
+        return exclusions.only_if(check)
 
     @property
     def tidb_zero_date(self):
@@ -120,14 +108,14 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
             )
             return not row or "NO_ZERO_DATE" not in row[1]
 
-        return only_if(check)
+        return exclusions.only_if(check)
 
     @property
     def precision_generic_float_type(self):
         """target backend will return native floating point numbers with at
         least seven decimal places when using the generic Float type."""
 
-        return fails_if(
+        return exclusions.fails_if(
             [
                 (
                     "tidb",
@@ -141,7 +129,7 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
     @property
     def sql_expression_limit_offset(self):
         return (
-                fails_if(
+                exclusions.fails_if(
                     ["tidb"],
                     "Target backend can't accommodate full expressions in "
                     "OFFSET or LIMIT",

--- a/sqlalchemy_tidb/requirements.py
+++ b/sqlalchemy_tidb/requirements.py
@@ -18,15 +18,80 @@ from sqlalchemy.testing.requirements \
 
 
 class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
-    temporary_tables = exclusions.closed()
-    temp_table_reflection = exclusions.closed()
     order_by_col_from_union = exclusions.open()
     time_microseconds = exclusions.closed()
-    foreign_keys = exclusions.closed()
+    datetime_microseconds = exclusions.closed()
+    autocommit = exclusions.open()
+    views = exclusions.open()
+    regexp_match = exclusions.open()
+    regexp_replace = exclusions.open()
+    sequences_optional = exclusions.open()
+    unicode_ddl = exclusions.open()
+    unbounded_varchar = exclusions.closed()
+    independent_cursors = exclusions.closed()
+    implicitly_named_constraints = exclusions.open()
+    table_ddl_if_exists = exclusions.open()
+    index_ddl_if_exists = exclusions.open()
+    comment_reflection = exclusions.open()
+    mod_operator_as_percent_sign = exclusions.open()
+    # https://github.com/pingcap/tidb/issues/45181
+    ctes = exclusions.closed()
 
-    @property
-    def reflects_json_type(self):
-        return only_on(["tidb"])
+    isolation_level = exclusions.open()
+    legacy_isolation_level = exclusions.open()
+    def get_isolation_levels(self, config):
+        return {
+            "default": "REPEATABLE READ",
+            "supported": [
+                "READ COMMITTED", "REPEATABLE READ",
+                "AUTOCOMMIT"
+            ]
+        }
+
+    def get_order_by_collation(self, config):
+        return 'utf8mb4_bin'
+
+    ad_hoc_engines = exclusions.open()
+
+    temporary_tables = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (5, 3, 0),
+        'versions before 5.3.0 do not support temporary tables',
+    )
+    # TiDB doesn't support CREATE INDEX for local temporary table
+    temp_table_reflect_indexes = exclusions.closed()
+    temp_table_reflection = exclusions.closed()
+
+    # https://github.com/pingcap/tidb/issues/45071
+    json_type = exclusions.closed()
+    reflects_json_type = exclusions.closed()
+
+    foreign_keys = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 6, 0),
+        'versions before 6.6.0 do not support foreign key reflection',
+    )
+    foreign_key_constraint_reflection = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 6, 0),
+        'versions before 6.6.0 do not support foreign key reflection',
+    )
+    self_referential_foreign_keys = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 6, 0),
+        'versions before 6.6.0 do not support foreign key reflection',
+    )
+
+    savepoints = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 2, 0),
+        'versions before 6.2.0 do not support savepoints',
+    )
+    savepoints_w_release = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 2, 0),
+        'versions before 6.2.0 do not support savepoints',
+    )
+    compat_savepoints = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 2, 0),
+        'versions before 6.2.0 do not support savepoints',
+    )
+
+    updateable_autoincrement_pks = exclusions.open()
 
     @property
     def tidb_non_strict(self):
@@ -51,51 +116,6 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
             return not row or "NO_ZERO_DATE" not in row[1]
 
         return only_if(check)
-
-    @property
-    def datetime_microseconds(self):
-        """target dialect supports representation of Python
-        datetime.datetime() with microsecond objects."""
-
-        return skip_if(
-            ["tidb"]
-        )
-
-    @property
-    def unicode_ddl(self):
-        """Target driver must support some degree of non-ascii symbol names."""
-
-        return only_on(["tidb"])
-
-    @property
-    def unbounded_varchar(self):
-        """Target database must support VARCHAR with no length"""
-
-        return skip_if(
-            ["firebird", "oracle", "mysql", "mariadb", "tidb"],
-            "not supported by database",
-        )
-
-    @property
-    def independent_cursors(self):
-        """Target must support simultaneous, independent database cursors
-        on a single connection."""
-
-        return skip_if(["tidb"], "no driver support")
-
-    @property
-    def self_referential_foreign_keys(self):
-        """Target database must support self-referential foreign keys."""
-
-        return exclusions.closed()
-
-    @property
-    def foreign_key_constraint_reflection(self):
-        return exclusions.closed()
-
-    @property
-    def implicitly_named_constraints(self):
-        return exclusions.open()
 
     @property
     def precision_generic_float_type(self):
@@ -123,23 +143,3 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
                 )
                 + self.offset
         )
-
-    @property
-    def table_ddl_if_exists(self):
-        """target platform supports IF NOT EXISTS / IF EXISTS for tables."""
-        return only_on(["tidb"])
-
-    @property
-    def index_ddl_if_exists(self):
-        """target platform supports IF NOT EXISTS / IF EXISTS for indexes."""
-        return only_on(["tidb"])
-
-    @property
-    def comment_reflection(self):
-        return only_on(["tidb"])
-
-    @property
-    def mod_operator_as_percent_sign(self):
-        """target database must use a plain percent '%' as the 'modulus'
-        operator."""
-        return only_if(["tidb"])

--- a/sqlalchemy_tidb/requirements.py
+++ b/sqlalchemy_tidb/requirements.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 from alembic.testing.requirements \
     import SuiteRequirements as SuiteRequirementsAlembic
-from sqlalchemy.testing import exclusions, skip_if, fails_if, only_on, only_if
+from sqlalchemy.testing import exclusions, fails_if, only_if
 from sqlalchemy.testing.requirements \
     import SuiteRequirements as SuiteRequirementsSQLA
 
@@ -43,6 +43,7 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
 
     isolation_level = exclusions.open()
     legacy_isolation_level = exclusions.open()
+
     def get_isolation_levels(self, config):
         return {
             "default": "REPEATABLE READ",

--- a/sqlalchemy_tidb/requirements.py
+++ b/sqlalchemy_tidb/requirements.py
@@ -24,7 +24,6 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
     autocommit = exclusions.open()
     views = exclusions.open()
     regexp_match = exclusions.open()
-    regexp_replace = exclusions.open()
     sequences_optional = exclusions.open()
     unicode_ddl = exclusions.open()
     unbounded_varchar = exclusions.closed()
@@ -36,6 +35,11 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
     mod_operator_as_percent_sign = exclusions.open()
     # https://github.com/pingcap/tidb/issues/45181
     ctes = exclusions.closed()
+
+    regexp_replace = exclusions.skip_if(
+        lambda config: config.db.dialect.tidb_version < (6, 5, 0),
+        'versions before 6.5.0 do not support regexp_replace',
+    )
 
     isolation_level = exclusions.open()
     legacy_isolation_level = exclusions.open()

--- a/test/_orm_fixtures.py
+++ b/test/_orm_fixtures.py
@@ -1,0 +1,609 @@
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import util
+from sqlalchemy.orm import backref
+from sqlalchemy.orm import configure_mappers
+from sqlalchemy.orm import mapper
+from sqlalchemy.orm import relationship
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.schema import Column
+from sqlalchemy.testing.schema import Table
+
+
+__all__ = ()
+
+
+class FixtureTest(fixtures.MappedTest):
+    """A MappedTest pre-configured with a common set of fixtures."""
+
+    run_define_tables = "once"
+    run_setup_classes = "once"
+    run_setup_mappers = "each"
+    run_inserts = "each"
+    run_deletes = "each"
+
+    @classmethod
+    def setup_classes(cls):
+        class Base(cls.Comparable):
+            pass
+
+        class User(Base):
+            pass
+
+        class Order(Base):
+            pass
+
+        class Item(Base):
+            pass
+
+        class Keyword(Base):
+            pass
+
+        class Address(Base):
+            pass
+
+        class Dingaling(Base):
+            pass
+
+        class HasDingaling(Base):
+            pass
+
+        class Node(Base):
+            pass
+
+        class CompositePk(Base):
+            pass
+
+    @classmethod
+    def _setup_stock_mapping(cls):
+        (
+            Node,
+            composite_pk_table,
+            users,
+            Keyword,
+            items,
+            Dingaling,
+            order_items,
+            item_keywords,
+            Item,
+            User,
+            dingalings,
+            Address,
+            keywords,
+            CompositePk,
+            nodes,
+            Order,
+            orders,
+            addresses,
+        ) = (
+            cls.classes.Node,
+            cls.tables.composite_pk_table,
+            cls.tables.users,
+            cls.classes.Keyword,
+            cls.tables.items,
+            cls.classes.Dingaling,
+            cls.tables.order_items,
+            cls.tables.item_keywords,
+            cls.classes.Item,
+            cls.classes.User,
+            cls.tables.dingalings,
+            cls.classes.Address,
+            cls.tables.keywords,
+            cls.classes.CompositePk,
+            cls.tables.nodes,
+            cls.classes.Order,
+            cls.tables.orders,
+            cls.tables.addresses,
+        )
+
+        # use OrderedDict on this one to support some tests that
+        # assert the order of attributes (e.g. orm/test_inspect)
+        mapper(
+            User,
+            users,
+            properties=util.OrderedDict(
+                [
+                    (
+                        "addresses",
+                        relationship(
+                            Address, backref="user", order_by=addresses.c.id
+                        ),
+                    ),
+                    (
+                        "orders",
+                        relationship(
+                            Order, backref="user", order_by=orders.c.id
+                        ),
+                    ),  # o2m, m2o
+                ]
+            ),
+        )
+        mapper(
+            Address,
+            addresses,
+            properties={
+                # o2o
+                "dingaling": relationship(
+                    Dingaling, uselist=False, backref="address"
+                )
+            },
+        )
+        mapper(Dingaling, dingalings)
+        mapper(
+            Order,
+            orders,
+            properties={
+                # m2m
+                "items": relationship(
+                    Item, secondary=order_items, order_by=items.c.id
+                ),
+                "address": relationship(Address),  # m2o
+            },
+        )
+        mapper(
+            Item,
+            items,
+            properties={
+                "keywords": relationship(
+                    Keyword, secondary=item_keywords
+                )  # m2m
+            },
+        )
+        mapper(Keyword, keywords)
+        mapper(
+            Node,
+            nodes,
+            properties={
+                "children": relationship(
+                    Node, backref=backref("parent", remote_side=[nodes.c.id])
+                )
+            },
+        )
+
+        mapper(CompositePk, composite_pk_table)
+
+        configure_mappers()
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "users",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("name", String(30), nullable=False),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "addresses",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("user_id", None, ForeignKey("users.id")),
+            Column("email_address", String(50), nullable=False),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "email_bounces",
+            metadata,
+            Column("id", Integer, ForeignKey("addresses.id")),
+            Column("bounces", Integer),
+        )
+
+        Table(
+            "orders",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("user_id", None, ForeignKey("users.id")),
+            Column("address_id", None, ForeignKey("addresses.id")),
+            Column("description", String(30)),
+            Column("isopen", Integer),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "dingalings",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("address_id", None, ForeignKey("addresses.id")),
+            Column("data", String(30)),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "has_dingaling",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("dingaling_id", None, ForeignKey("dingalings.id")),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "items",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("description", String(30), nullable=False),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "order_items",
+            metadata,
+            Column("item_id", None, ForeignKey("items.id")),
+            Column("order_id", None, ForeignKey("orders.id")),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "keywords",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("name", String(30), nullable=False),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "item_keywords",
+            metadata,
+            Column("item_id", None, ForeignKey("items.id")),
+            Column("keyword_id", None, ForeignKey("keywords.id")),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "nodes",
+            metadata,
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("parent_id", Integer, ForeignKey("nodes.id")),
+            Column("data", String(30)),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "composite_pk_table",
+            metadata,
+            Column("i", Integer, primary_key=True),
+            Column("j", Integer, primary_key=True),
+            Column("k", Integer, nullable=False),
+        )
+
+    @classmethod
+    def setup_mappers(cls):
+        pass
+
+    @classmethod
+    def fixtures(cls):
+        return dict(
+            users=(
+                ("id", "name"),
+                (7, "jack"),
+                (8, "ed"),
+                (9, "fred"),
+                (10, "chuck"),
+            ),
+            addresses=(
+                ("id", "user_id", "email_address"),
+                (1, 7, "jack@bean.com"),
+                (2, 8, "ed@wood.com"),
+                (3, 8, "ed@bettyboop.com"),
+                (4, 8, "ed@lala.com"),
+                (5, 9, "fred@fred.com"),
+            ),
+            email_bounces=(
+                ("id", "bounces"),
+                (1, 1),
+                (2, 0),
+                (3, 5),
+                (4, 0),
+                (5, 0),
+            ),
+            orders=(
+                ("id", "user_id", "description", "isopen", "address_id"),
+                (1, 7, "order 1", 0, 1),
+                (2, 9, "order 2", 0, 4),
+                (3, 7, "order 3", 1, 1),
+                (4, 9, "order 4", 1, 4),
+                (5, 7, "order 5", 0, None),
+            ),
+            dingalings=(
+                ("id", "address_id", "data"),
+                (1, 2, "ding 1/2"),
+                (2, 5, "ding 2/5"),
+            ),
+            items=(
+                ("id", "description"),
+                (1, "item 1"),
+                (2, "item 2"),
+                (3, "item 3"),
+                (4, "item 4"),
+                (5, "item 5"),
+            ),
+            order_items=(
+                ("item_id", "order_id"),
+                (1, 1),
+                (2, 1),
+                (3, 1),
+                (1, 2),
+                (2, 2),
+                (3, 2),
+                (3, 3),
+                (4, 3),
+                (5, 3),
+                (1, 4),
+                (5, 4),
+                (5, 5),
+            ),
+            keywords=(
+                ("id", "name"),
+                (1, "blue"),
+                (2, "red"),
+                (3, "green"),
+                (4, "big"),
+                (5, "small"),
+                (6, "round"),
+                (7, "square"),
+            ),
+            item_keywords=(
+                ("keyword_id", "item_id"),
+                (2, 1),
+                (2, 2),
+                (4, 1),
+                (6, 1),
+                (5, 2),
+                (3, 3),
+                (4, 3),
+                (7, 2),
+                (6, 3),
+            ),
+            nodes=(("id", "parent_id", "data"),),
+            composite_pk_table=(
+                ("i", "j", "k"),
+                (1, 2, 3),
+                (2, 1, 4),
+                (1, 1, 5),
+                (2, 2, 6),
+            ),
+        )
+
+    @util.memoized_property
+    def static(self):
+        return CannedResults(self)
+
+
+class CannedResults(object):
+    """Built on demand, instances use mappers in effect at time of call."""
+
+    def __init__(self, test):
+        self.test = test
+
+    @property
+    def user_result(self):
+        User = self.test.classes.User
+
+        return [User(id=7), User(id=8), User(id=9), User(id=10)]
+
+    @property
+    def user_address_result(self):
+        User, Address = self.test.classes.User, self.test.classes.Address
+
+        return [
+            User(id=7, addresses=[Address(id=1)]),
+            User(
+                id=8,
+                addresses=[
+                    Address(id=2, email_address="ed@wood.com"),
+                    Address(id=3, email_address="ed@bettyboop.com"),
+                    Address(id=4, email_address="ed@lala.com"),
+                ],
+            ),
+            User(id=9, addresses=[Address(id=5)]),
+            User(id=10, addresses=[]),
+        ]
+
+    @property
+    def address_user_result(self):
+        User, Address = self.test.classes.User, self.test.classes.Address
+        u7 = User(id=7)
+        u8 = User(id=8)
+        u9 = User(id=9)
+        return [
+            Address(id=1, email_address="jack@bean.com", user=u7),
+            Address(id=2, email_address="ed@wood.com", user=u8),
+            Address(id=3, email_address="ed@bettyboop.com", user=u8),
+            Address(id=4, email_address="ed@lala.com", user=u8),
+            Address(id=5, user=u9),
+        ]
+
+    @property
+    def user_all_result(self):
+        User, Address, Order, Item = (
+            self.test.classes.User,
+            self.test.classes.Address,
+            self.test.classes.Order,
+            self.test.classes.Item,
+        )
+
+        return [
+            User(
+                id=7,
+                addresses=[Address(id=1)],
+                orders=[
+                    Order(
+                        description="order 1",
+                        items=[
+                            Item(description="item 1"),
+                            Item(description="item 2"),
+                            Item(description="item 3"),
+                        ],
+                    ),
+                    Order(description="order 3"),
+                    Order(description="order 5"),
+                ],
+            ),
+            User(
+                id=8, addresses=[Address(id=2), Address(id=3), Address(id=4)]
+            ),
+            User(
+                id=9,
+                addresses=[Address(id=5)],
+                orders=[
+                    Order(
+                        description="order 2",
+                        items=[
+                            Item(description="item 1"),
+                            Item(description="item 2"),
+                            Item(description="item 3"),
+                        ],
+                    ),
+                    Order(
+                        description="order 4",
+                        items=[
+                            Item(description="item 1"),
+                            Item(description="item 5"),
+                        ],
+                    ),
+                ],
+            ),
+            User(id=10, addresses=[]),
+        ]
+
+    @property
+    def user_order_result(self):
+        User, Order, Item = (
+            self.test.classes.User,
+            self.test.classes.Order,
+            self.test.classes.Item,
+        )
+        return [
+            User(
+                id=7,
+                orders=[
+                    Order(id=1, items=[Item(id=1), Item(id=2), Item(id=3)]),
+                    Order(id=3, items=[Item(id=3), Item(id=4), Item(id=5)]),
+                    Order(id=5, items=[Item(id=5)]),
+                ],
+            ),
+            User(id=8, orders=[]),
+            User(
+                id=9,
+                orders=[
+                    Order(id=2, items=[Item(id=1), Item(id=2), Item(id=3)]),
+                    Order(id=4, items=[Item(id=1), Item(id=5)]),
+                ],
+            ),
+            User(id=10),
+        ]
+
+    @property
+    def item_keyword_result(self):
+        Item, Keyword = self.test.classes.Item, self.test.classes.Keyword
+        return [
+            Item(
+                id=1,
+                keywords=[
+                    Keyword(name="red"),
+                    Keyword(name="big"),
+                    Keyword(name="round"),
+                ],
+            ),
+            Item(
+                id=2,
+                keywords=[
+                    Keyword(name="red"),
+                    Keyword(name="small"),
+                    Keyword(name="square"),
+                ],
+            ),
+            Item(
+                id=3,
+                keywords=[
+                    Keyword(name="green"),
+                    Keyword(name="big"),
+                    Keyword(name="round"),
+                ],
+            ),
+            Item(id=4, keywords=[]),
+            Item(id=5, keywords=[]),
+        ]
+
+    @property
+    def user_item_keyword_result(self):
+        Item, Keyword = self.test.classes.Item, self.test.classes.Keyword
+        User, Order = self.test.classes.User, self.test.classes.Order
+
+        item1, item2, item3, item4, item5 = (
+            Item(
+                id=1,
+                keywords=[
+                    Keyword(name="red"),
+                    Keyword(name="big"),
+                    Keyword(name="round"),
+                ],
+            ),
+            Item(
+                id=2,
+                keywords=[
+                    Keyword(name="red"),
+                    Keyword(name="small"),
+                    Keyword(name="square"),
+                ],
+            ),
+            Item(
+                id=3,
+                keywords=[
+                    Keyword(name="green"),
+                    Keyword(name="big"),
+                    Keyword(name="round"),
+                ],
+            ),
+            Item(id=4, keywords=[]),
+            Item(id=5, keywords=[]),
+        )
+
+        user_result = [
+            User(
+                id=7,
+                orders=[
+                    Order(id=1, items=[item1, item2, item3]),
+                    Order(id=3, items=[item3, item4, item5]),
+                    Order(id=5, items=[item5]),
+                ],
+            ),
+            User(id=8, orders=[]),
+            User(
+                id=9,
+                orders=[
+                    Order(id=2, items=[item1, item2, item3]),
+                    Order(id=4, items=[item1, item5]),
+                ],
+            ),
+            User(id=10, orders=[]),
+        ]
+        return user_result

--- a/test/test_engin_transaction.py
+++ b/test/test_engin_transaction.py
@@ -1,0 +1,1829 @@
+import sys
+
+from sqlalchemy import event
+from sqlalchemy import exc
+from sqlalchemy import func
+from sqlalchemy import INT
+from sqlalchemy import MetaData
+from sqlalchemy import pool as _pool
+from sqlalchemy import select
+from sqlalchemy import testing
+from sqlalchemy import util
+from sqlalchemy import VARCHAR
+from sqlalchemy.engine import base
+from sqlalchemy.engine import characteristics
+from sqlalchemy.engine import default
+from sqlalchemy.engine import url
+from sqlalchemy.testing import assert_raises_message
+from sqlalchemy.testing import eq_
+from sqlalchemy.testing import expect_warnings
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing import mock
+from sqlalchemy.testing import ne_
+from sqlalchemy.testing.assertions import expect_deprecated_20
+from sqlalchemy.testing.assertions import expect_raises_message
+from sqlalchemy.testing.engines import testing_engine
+from sqlalchemy.testing.schema import Column
+from sqlalchemy.testing.schema import Table
+
+
+class TransactionTest(fixtures.TablesTest):
+    __backend__ = True
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "users",
+            metadata,
+            Column("user_id", INT, primary_key=True),
+            Column("user_name", VARCHAR(20)),
+            test_needs_acid=True,
+        )
+
+    @testing.fixture
+    def local_connection(self):
+        with testing.db.connect() as conn:
+            yield conn
+
+    def test_interrupt_ctxmanager_engine(self, trans_ctx_manager_fixture):
+        fn = trans_ctx_manager_fixture
+
+        # add commit/rollback to the legacy Connection object so that
+        # we can test this less-likely case in use with the legacy
+        # Engine.begin() context manager
+        class ConnWCommitRollback(testing.db._connection_cls):
+            def commit(self):
+                self.get_transaction().commit()
+
+            def rollback(self):
+                self.get_transaction().rollback()
+
+        with mock.patch.object(
+            testing.db, "_connection_cls", ConnWCommitRollback
+        ):
+            fn(testing.db, trans_on_subject=False, execute_on_subject=False)
+
+    def test_interrupt_ctxmanager_connection(self, trans_ctx_manager_fixture):
+        fn = trans_ctx_manager_fixture
+
+        with testing.db.connect() as conn:
+            fn(conn, trans_on_subject=False, execute_on_subject=True)
+
+    def test_commits(self, local_connection):
+        users = self.tables.users
+        connection = local_connection
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        transaction.commit()
+
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        connection.execute(users.insert(), dict(user_id=3, user_name="user3"))
+        transaction.commit()
+
+        transaction = connection.begin()
+        result = connection.exec_driver_sql("select * from users")
+        assert len(result.fetchall()) == 3
+        transaction.commit()
+        connection.close()
+
+    def test_rollback(self, local_connection):
+        """test a basic rollback"""
+
+        users = self.tables.users
+        connection = local_connection
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        connection.execute(users.insert(), dict(user_id=3, user_name="user3"))
+        transaction.rollback()
+        result = connection.exec_driver_sql("select * from users")
+        assert len(result.fetchall()) == 0
+
+    def test_raise(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+
+        transaction = connection.begin()
+        try:
+            connection.execute(
+                users.insert(), dict(user_id=1, user_name="user1")
+            )
+            connection.execute(
+                users.insert(), dict(user_id=2, user_name="user2")
+            )
+            connection.execute(
+                users.insert(), dict(user_id=1, user_name="user3")
+            )
+            transaction.commit()
+            assert False
+        except Exception as e:
+            print("Exception: ", e)
+            transaction.rollback()
+
+        result = connection.exec_driver_sql("select * from users")
+        assert len(result.fetchall()) == 0
+
+    def test_rollback_end_ctx_manager_autocommit(self, local_connection):
+        m1 = mock.Mock()
+
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+
+        with local_connection.begin() as trans:
+            assert local_connection.in_transaction()
+            trans.rollback()
+            assert not local_connection.in_transaction()
+
+            # previously, would be subject to autocommit.
+            # now it raises
+            with expect_raises_message(
+                exc.InvalidRequestError,
+                "Can't operate on closed transaction inside context manager.  "
+                "Please complete the context manager before emitting "
+                "further commands.",
+            ):
+                local_connection.execute(select(1))
+
+            assert not local_connection.in_transaction()
+
+    @testing.combinations((True,), (False,), argnames="roll_back_in_block")
+    def test_ctxmanager_rolls_back(self, local_connection, roll_back_in_block):
+        m1 = mock.Mock()
+
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+
+        with expect_raises_message(Exception, "test"):
+            with local_connection.begin() as trans:
+                if roll_back_in_block:
+                    trans.rollback()
+
+                if 1 == 1:
+                    raise Exception("test")
+
+        assert not trans.is_active
+        assert not local_connection.in_transaction()
+        assert trans._deactivated_from_connection
+
+        eq_(m1.mock_calls, [mock.call.rollback(local_connection)])
+
+    @testing.combinations((True,), (False,), argnames="roll_back_in_block")
+    def test_ctxmanager_rolls_back_legacy_marker(
+        self, local_connection, roll_back_in_block
+    ):
+        m1 = mock.Mock()
+
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+
+        with expect_deprecated_20(
+            r"Calling .begin\(\) when a transaction is already begun"
+        ):
+            with local_connection.begin() as trans:
+                with expect_raises_message(Exception, "test"):
+                    with local_connection.begin() as marker_trans:
+                        if roll_back_in_block:
+                            marker_trans.rollback()
+                        if 1 == 1:
+                            raise Exception("test")
+
+                    assert not marker_trans.is_active
+                    assert marker_trans._deactivated_from_connection
+
+                assert not trans._deactivated_from_connection
+                assert not trans.is_active
+                assert not local_connection.in_transaction()
+
+        eq_(m1.mock_calls, [mock.call.rollback(local_connection)])
+
+    @testing.combinations((True,), (False,), argnames="roll_back_in_block")
+    @testing.requires.savepoints
+    def test_ctxmanager_rolls_back_savepoint(
+        self, local_connection, roll_back_in_block
+    ):
+        m1 = mock.Mock()
+
+        event.listen(
+            local_connection, "rollback_savepoint", m1.rollback_savepoint
+        )
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+
+        with local_connection.begin() as trans:
+            with expect_raises_message(Exception, "test"):
+                with local_connection.begin_nested() as nested_trans:
+                    if roll_back_in_block:
+                        nested_trans.rollback()
+                    if 1 == 1:
+                        raise Exception("test")
+
+                assert not nested_trans.is_active
+                assert nested_trans._deactivated_from_connection
+
+            assert trans.is_active
+            assert local_connection.in_transaction()
+            assert not trans._deactivated_from_connection
+
+        eq_(
+            m1.mock_calls,
+            [
+                mock.call.rollback_savepoint(
+                    local_connection, mock.ANY, mock.ANY
+                ),
+                mock.call.commit(local_connection),
+            ],
+        )
+
+    def test_ctxmanager_commits_real_trans_from_nested(self, local_connection):
+        m1 = mock.Mock()
+
+        event.listen(
+            local_connection, "rollback_savepoint", m1.rollback_savepoint
+        )
+        event.listen(
+            local_connection, "release_savepoint", m1.release_savepoint
+        )
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+        event.listen(local_connection, "begin", m1.begin)
+        event.listen(local_connection, "savepoint", m1.savepoint)
+
+        with testing.expect_deprecated_20(
+            r"Calling Connection.begin_nested\(\) in 2.0 style use will return"
+        ):
+            with local_connection.begin_nested() as nested_trans:
+                pass
+
+        assert not nested_trans.is_active
+        assert nested_trans._deactivated_from_connection
+        # legacy mode, no savepoint at all
+        eq_(
+            m1.mock_calls,
+            [
+                mock.call.begin(local_connection),
+                mock.call.commit(local_connection),
+            ],
+        )
+
+    def test_deactivated_warning_straight(self, local_connection):
+        with expect_warnings(
+            "transaction already deassociated from connection"
+        ):
+            trans = local_connection.begin()
+            trans.rollback()
+            trans.rollback()
+
+    @testing.requires.savepoints
+    def test_deactivated_savepoint_warning_straight(self, local_connection):
+        with expect_warnings(
+            "nested transaction already deassociated from connection"
+        ):
+            with local_connection.begin():
+                savepoint = local_connection.begin_nested()
+                savepoint.rollback()
+                savepoint.rollback()
+
+    def test_commit_fails_flat(self, local_connection):
+        connection = local_connection
+
+        t1 = connection.begin()
+
+        with mock.patch.object(
+            connection,
+            "_commit_impl",
+            mock.Mock(side_effect=exc.DBAPIError("failure", None, None, None)),
+        ):
+            assert_raises_message(exc.DBAPIError, r"failure", t1.commit)
+
+        assert not t1.is_active
+        t1.rollback()  # no error
+
+    def test_commit_fails_ctxmanager(self, local_connection):
+        connection = local_connection
+
+        transaction = [None]
+
+        def go():
+            with mock.patch.object(
+                connection,
+                "_commit_impl",
+                mock.Mock(
+                    side_effect=exc.DBAPIError("failure", None, None, None)
+                ),
+            ):
+                with connection.begin() as t1:
+                    transaction[0] = t1
+
+        assert_raises_message(exc.DBAPIError, r"failure", go)
+
+        t1 = transaction[0]
+        assert not t1.is_active
+        with expect_warnings(
+            "transaction already deassociated from connection"
+        ):
+            t1.rollback()  # no error
+
+    @testing.requires.savepoints_w_release
+    def test_savepoint_rollback_fails_flat(self, local_connection):
+        connection = local_connection
+        t1 = connection.begin()
+
+        s1 = connection.begin_nested()
+
+        # force the "commit" of the savepoint that occurs
+        # when the "with" block fails, e.g.
+        # the RELEASE, to fail, because the savepoint is already
+        # released.
+        connection.dialect.do_release_savepoint(connection, s1._savepoint)
+
+        assert_raises_message(
+            exc.DBAPIError, r".*SQL\:.*ROLLBACK TO SAVEPOINT", s1.rollback
+        )
+
+        assert not s1.is_active
+
+        with testing.expect_warnings("nested transaction already"):
+            s1.rollback()  # no error (though it warns)
+
+        t1.commit()  # no error
+
+    @testing.requires.savepoints_w_release
+    def test_savepoint_release_fails_flat(self):
+        with testing.db.connect() as connection:
+            t1 = connection.begin()
+
+            s1 = connection.begin_nested()
+
+            # force the "commit" of the savepoint that occurs
+            # when the "with" block fails, e.g.
+            # the RELEASE, to fail, because the savepoint is already
+            # released.
+            connection.dialect.do_release_savepoint(connection, s1._savepoint)
+
+            assert_raises_message(
+                exc.DBAPIError, r".*SQL\:.*RELEASE SAVEPOINT", s1.commit
+            )
+
+            assert not s1.is_active
+            s1.rollback()  # no error.  prior to 1.4 this would try to rollback
+
+            t1.commit()  # no error
+
+    @testing.requires.savepoints_w_release
+    def test_savepoint_release_fails_ctxmanager(self, local_connection):
+        connection = local_connection
+        connection.begin()
+
+        savepoint = [None]
+
+        def go():
+
+            with connection.begin_nested() as sp:
+                savepoint[0] = sp
+                # force the "commit" of the savepoint that occurs
+                # when the "with" block fails, e.g.
+                # the RELEASE, to fail, because the savepoint is already
+                # released.
+                connection.dialect.do_release_savepoint(
+                    connection, sp._savepoint
+                )
+
+        # prior to SQLAlchemy 1.4, the above release would fail
+        # and then the savepoint would try to rollback, and that failed
+        # also, causing a long exception chain that under Python 2
+        # was particularly hard to diagnose, leading to issue
+        # #2696 which eventually impacted Openstack, and we
+        # had to add warnings that show what the "context" for an
+        # exception was.   The SQL for the exception was
+        # ROLLBACK TO SAVEPOINT, and up the exception chain would be
+        # the RELEASE failing.
+        #
+        # now, when the savepoint "commit" fails, it sets itself as
+        # inactive.   so it does not try to rollback and it cleans
+        # itself out appropriately.
+        #
+
+        exc_ = assert_raises_message(
+            exc.DBAPIError, r".*SQL\:.*RELEASE SAVEPOINT", go
+        )
+        savepoint = savepoint[0]
+        assert not savepoint.is_active
+
+        if util.py3k:
+            # ensure cause comes from the DBAPI
+            assert isinstance(exc_.__cause__, testing.db.dialect.dbapi.Error)
+
+    def test_retains_through_options(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        conn2 = connection.execution_options(dummy=True)
+        conn2.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        transaction.rollback()
+        eq_(
+            connection.exec_driver_sql("select count(*) from users").scalar(),
+            0,
+        )
+
+    def test_with_interface(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+        trans = connection.begin()
+        trans.__enter__()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        try:
+            connection.execute(
+                users.insert(), dict(user_id=2, user_name="user2.5")
+            )
+        except Exception:
+            trans.__exit__(*sys.exc_info())
+
+        assert not trans.is_active
+        self.assert_(
+            connection.exec_driver_sql(
+                "select count(*) from " "users"
+            ).scalar()
+            == 0
+        )
+
+        trans = connection.begin()
+        trans.__enter__()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        trans.__exit__(None, None, None)
+        assert not trans.is_active
+        self.assert_(
+            connection.exec_driver_sql(
+                "select count(*) from " "users"
+            ).scalar()
+            == 1
+        )
+
+    def test_close(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        connection.execute(users.insert(), dict(user_id=3, user_name="user3"))
+        assert connection.in_transaction()
+        transaction.commit()
+        assert not connection.in_transaction()
+        result = connection.exec_driver_sql("select * from users")
+        eq_(len(result.fetchall()), 3)
+
+    def test_close2(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        connection.execute(users.insert(), dict(user_id=3, user_name="user3"))
+        assert connection.in_transaction()
+        transaction.close()
+        assert not connection.in_transaction()
+        result = connection.exec_driver_sql("select * from users")
+        assert len(result.fetchall()) == 0
+
+    @testing.requires.savepoints
+    def test_nested_subtransaction_rollback(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        trans2 = connection.begin_nested()
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        trans2.rollback()
+        connection.execute(users.insert(), dict(user_id=3, user_name="user3"))
+        transaction.commit()
+        eq_(
+            connection.execute(
+                select(users.c.user_id).order_by(users.c.user_id)
+            ).fetchall(),
+            [(1,), (3,)],
+        )
+
+    @testing.requires.savepoints
+    def test_nested_subtransaction_commit(self, local_connection):
+        connection = local_connection
+        users = self.tables.users
+        transaction = connection.begin()
+        connection.execute(users.insert(), dict(user_id=1, user_name="user1"))
+        trans2 = connection.begin_nested()
+        connection.execute(users.insert(), dict(user_id=2, user_name="user2"))
+        trans2.commit()
+        connection.execute(users.insert(), dict(user_id=3, user_name="user3"))
+        transaction.commit()
+        eq_(
+            connection.execute(
+                select(users.c.user_id).order_by(users.c.user_id)
+            ).fetchall(),
+            [(1,), (2,), (3,)],
+        )
+
+
+class AutoRollbackTest(fixtures.TestBase):
+    __backend__ = True
+
+    @classmethod
+    def setup_test_class(cls):
+        global metadata
+        metadata = MetaData()
+
+    @classmethod
+    def teardown_test_class(cls):
+        metadata.drop_all(testing.db)
+
+    def test_rollback_deadlock(self):
+        """test that returning connections to the pool clears any object
+        locks."""
+
+        conn1 = testing.db.connect()
+        conn2 = testing.db.connect()
+        users = Table(
+            "deadlock_users",
+            metadata,
+            Column("user_id", INT, primary_key=True),
+            Column("user_name", VARCHAR(20)),
+            test_needs_acid=True,
+        )
+        with conn1.begin():
+            users.create(conn1)
+        conn1.exec_driver_sql("select * from deadlock_users")
+        conn1.close()
+
+        # without auto-rollback in the connection pool's return() logic,
+        # this deadlocks in PostgreSQL, because conn1 is returned to the
+        # pool but still has a lock on "deadlock_users". comment out the
+        # rollback in pool/ConnectionFairy._close() to see !
+
+        with conn2.begin():
+            users.drop(conn2)
+        conn2.close()
+
+
+class IsolationLevelTest(fixtures.TestBase):
+    __requires__ = (
+        "isolation_level",
+        "ad_hoc_engines",
+        "legacy_isolation_level",
+    )
+    __backend__ = True
+
+    def _default_isolation_level(self):
+        return testing.requires.get_isolation_levels(testing.config)["default"]
+
+    def _non_default_isolation_level(self):
+        levels = testing.requires.get_isolation_levels(testing.config)
+
+        default = levels["default"]
+        supported = levels["supported"]
+
+        s = set(supported).difference(["AUTOCOMMIT", default])
+        if s:
+            return s.pop()
+        else:
+            assert False, "no non-default isolation level available"
+
+    def test_engine_param_stays(self):
+
+        eng = testing_engine()
+        isolation_level = eng.dialect.get_isolation_level(
+            eng.connect().connection
+        )
+        level = self._non_default_isolation_level()
+
+        ne_(isolation_level, level)
+
+        eng = testing_engine(options=dict(isolation_level=level))
+        eq_(eng.dialect.get_isolation_level(eng.connect().connection), level)
+
+        # check that it stays
+        conn = eng.connect()
+        eq_(eng.dialect.get_isolation_level(conn.connection), level)
+        conn.close()
+
+        conn = eng.connect()
+        eq_(eng.dialect.get_isolation_level(conn.connection), level)
+        conn.close()
+
+    def test_default_level(self):
+        eng = testing_engine(options=dict())
+        isolation_level = eng.dialect.get_isolation_level(
+            eng.connect().connection
+        )
+        eq_(isolation_level, self._default_isolation_level())
+
+    def test_reset_level(self):
+        eng = testing_engine(options=dict())
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level(),
+        )
+
+        eng.dialect.set_isolation_level(
+            conn.connection, self._non_default_isolation_level()
+        )
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level(),
+        )
+
+        eng.dialect.reset_isolation_level(conn.connection)
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level(),
+        )
+
+        conn.close()
+
+    def test_reset_level_with_setting(self):
+        eng = testing_engine(
+            options=dict(isolation_level=self._non_default_isolation_level())
+        )
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level(),
+        )
+        eng.dialect.set_isolation_level(
+            conn.connection, self._default_isolation_level()
+        )
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level(),
+        )
+        eng.dialect.reset_isolation_level(conn.connection)
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level(),
+        )
+        conn.close()
+
+    def test_invalid_level(self):
+        eng = testing_engine(options=dict(isolation_level="FOO"))
+        assert_raises_message(
+            exc.ArgumentError,
+            "Invalid value '%s' for isolation_level. "
+            "Valid isolation levels for %s are %s"
+            % (
+                "FOO",
+                eng.dialect.name,
+                ", ".join(eng.dialect._isolation_lookup),
+            ),
+            eng.connect,
+        )
+
+    def test_connection_invalidated(self):
+        eng = testing_engine()
+        conn = eng.connect()
+        c2 = conn.execution_options(
+            isolation_level=self._non_default_isolation_level()
+        )
+        c2.invalidate()
+        c2.connection
+
+        # TODO: do we want to rebuild the previous isolation?
+        # for now, this is current behavior so we will leave it.
+        eq_(c2.get_isolation_level(), self._default_isolation_level())
+
+    def test_per_connection(self):
+        from sqlalchemy.pool import QueuePool
+
+        eng = testing_engine(
+            options=dict(poolclass=QueuePool, pool_size=2, max_overflow=0)
+        )
+
+        c1 = eng.connect()
+        c1 = c1.execution_options(
+            isolation_level=self._non_default_isolation_level()
+        )
+        c2 = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(c1.connection),
+            self._non_default_isolation_level(),
+        )
+        eq_(
+            eng.dialect.get_isolation_level(c2.connection),
+            self._default_isolation_level(),
+        )
+        c1.close()
+        c2.close()
+        c3 = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(c3.connection),
+            self._default_isolation_level(),
+        )
+        c4 = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(c4.connection),
+            self._default_isolation_level(),
+        )
+
+        c3.close()
+        c4.close()
+
+    def test_warning_in_transaction(self):
+        eng = testing_engine()
+        c1 = eng.connect()
+        with expect_warnings(
+            "Connection is already established with a Transaction; "
+            "setting isolation_level may implicitly rollback or commit "
+            "the existing transaction, or have no effect until next "
+            "transaction"
+        ):
+            with c1.begin():
+                c1 = c1.execution_options(
+                    isolation_level=self._non_default_isolation_level()
+                )
+
+                eq_(
+                    eng.dialect.get_isolation_level(c1.connection),
+                    self._non_default_isolation_level(),
+                )
+        # stays outside of transaction
+        eq_(
+            eng.dialect.get_isolation_level(c1.connection),
+            self._non_default_isolation_level(),
+        )
+
+    def test_per_statement_bzzt(self):
+        assert_raises_message(
+            exc.ArgumentError,
+            r"'isolation_level' execution option may only be specified "
+            r"on Connection.execution_options\(\), or "
+            r"per-engine using the isolation_level "
+            r"argument to create_engine\(\).",
+            select(1).execution_options,
+            isolation_level=self._non_default_isolation_level(),
+        )
+
+    def test_per_engine(self):
+        # new in 0.9
+        eng = testing_engine(
+            testing.db.url,
+            options=dict(
+                execution_options={
+                    "isolation_level": self._non_default_isolation_level()
+                }
+            ),
+        )
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level(),
+        )
+
+    def test_per_option_engine(self):
+        eng = testing_engine(testing.db.url).execution_options(
+            isolation_level=self._non_default_isolation_level()
+        )
+
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level(),
+        )
+
+    def test_isolation_level_accessors_connection_default(self):
+        eng = testing_engine(testing.db.url)
+        with eng.connect() as conn:
+            eq_(conn.default_isolation_level, self._default_isolation_level())
+        with eng.connect() as conn:
+            eq_(conn.get_isolation_level(), self._default_isolation_level())
+
+    def test_isolation_level_accessors_connection_option_modified(self):
+        eng = testing_engine(testing.db.url)
+        with eng.connect() as conn:
+            c2 = conn.execution_options(
+                isolation_level=self._non_default_isolation_level()
+            )
+            eq_(conn.default_isolation_level, self._default_isolation_level())
+            eq_(
+                conn.get_isolation_level(), self._non_default_isolation_level()
+            )
+            eq_(c2.get_isolation_level(), self._non_default_isolation_level())
+
+
+class ConnectionCharacteristicTest(fixtures.TestBase):
+    @testing.fixture
+    def characteristic_fixture(self):
+        class FooCharacteristic(characteristics.ConnectionCharacteristic):
+            transactional = True
+
+            def reset_characteristic(self, dialect, dbapi_conn):
+
+                dialect.reset_foo(dbapi_conn)
+
+            def set_characteristic(self, dialect, dbapi_conn, value):
+
+                dialect.set_foo(dbapi_conn, value)
+
+            def get_characteristic(self, dialect, dbapi_conn):
+                return dialect.get_foo(dbapi_conn)
+
+        class FooDialect(default.DefaultDialect):
+            connection_characteristics = util.immutabledict(
+                {"foo": FooCharacteristic()}
+            )
+
+            def reset_foo(self, dbapi_conn):
+                dbapi_conn.foo = "original_value"
+
+            def set_foo(self, dbapi_conn, value):
+                dbapi_conn.foo = value
+
+            def get_foo(self, dbapi_conn):
+                return dbapi_conn.foo
+
+        connection = mock.Mock()
+
+        def creator():
+            connection.foo = "original_value"
+            return connection
+
+        pool = _pool.SingletonThreadPool(creator=creator)
+        u = url.make_url("foo://")
+        return base.Engine(pool, FooDialect(), u), connection
+
+    def test_engine_param_stays(self, characteristic_fixture):
+
+        engine, connection = characteristic_fixture
+
+        foo_level = engine.dialect.get_foo(engine.connect().connection)
+
+        new_level = "new_level"
+
+        ne_(foo_level, new_level)
+
+        eng = engine.execution_options(foo=new_level)
+        eq_(eng.dialect.get_foo(eng.connect().connection), new_level)
+
+        # check that it stays
+        conn = eng.connect()
+        eq_(eng.dialect.get_foo(conn.connection), new_level)
+        conn.close()
+
+        conn = eng.connect()
+        eq_(eng.dialect.get_foo(conn.connection), new_level)
+        conn.close()
+
+    def test_default_level(self, characteristic_fixture):
+        engine, connection = characteristic_fixture
+
+        eq_(
+            engine.dialect.get_foo(engine.connect().connection),
+            "original_value",
+        )
+
+    def test_connection_invalidated(self, characteristic_fixture):
+        engine, connection = characteristic_fixture
+
+        conn = engine.connect()
+        c2 = conn.execution_options(foo="new_value")
+        eq_(connection.foo, "new_value")
+        c2.invalidate()
+        c2.connection
+
+        eq_(connection.foo, "original_value")
+
+    def test_warning_in_transaction(self, characteristic_fixture):
+        engine, connection = characteristic_fixture
+
+        c1 = engine.connect()
+        with expect_warnings(
+            "Connection is already established with a Transaction; "
+            "setting foo may implicitly rollback or commit "
+            "the existing transaction, or have no effect until next "
+            "transaction"
+        ):
+            with c1.begin():
+                c1 = c1.execution_options(foo="new_foo")
+
+                eq_(
+                    engine.dialect.get_foo(c1.connection),
+                    "new_foo",
+                )
+        # stays outside of transaction
+        eq_(engine.dialect.get_foo(c1.connection), "new_foo")
+
+    @testing.fails("no error is raised yet here.")
+    def test_per_statement_bzzt(self, characteristic_fixture):
+        engine, connection = characteristic_fixture
+
+        # this would need some on-execute mechanism to look inside of
+        # the characteristics list.   unfortunately this would
+        # add some latency.
+
+        assert_raises_message(
+            exc.ArgumentError,
+            r"'foo' execution option may only be specified "
+            r"on Connection.execution_options\(\), or "
+            r"per-engine using the isolation_level "
+            r"argument to create_engine\(\).",
+            connection.execute,
+            select([1]).execution_options(foo="bar"),
+        )
+
+    def test_per_engine(self, characteristic_fixture):
+
+        engine, connection = characteristic_fixture
+
+        pool, dialect, url = engine.pool, engine.dialect, engine.url
+
+        eng = base.Engine(
+            pool, dialect, url, execution_options={"foo": "new_value"}
+        )
+
+        conn = eng.connect()
+        eq_(eng.dialect.get_foo(conn.connection), "new_value")
+
+    def test_per_option_engine(self, characteristic_fixture):
+
+        engine, connection = characteristic_fixture
+
+        eng = engine.execution_options(foo="new_value")
+
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_foo(conn.connection),
+            "new_value",
+        )
+
+
+class ResetFixture(object):
+    @testing.fixture()
+    def reset_agent(self, testing_engine):
+        engine = testing_engine()
+        engine.connect().close()
+
+        harness = mock.Mock(
+            do_rollback=mock.Mock(side_effect=testing.db.dialect.do_rollback),
+            do_commit=mock.Mock(side_effect=testing.db.dialect.do_commit),
+            engine=engine,
+        )
+        event.listen(engine, "rollback", harness.rollback)
+        event.listen(engine, "commit", harness.commit)
+        event.listen(engine, "rollback_savepoint", harness.rollback_savepoint)
+        event.listen(engine, "rollback_twophase", harness.rollback_twophase)
+        event.listen(engine, "commit_twophase", harness.commit_twophase)
+
+        with mock.patch.object(
+            engine.dialect, "do_rollback", harness.do_rollback
+        ), mock.patch.object(engine.dialect, "do_commit", harness.do_commit):
+            yield harness
+
+        event.remove(engine, "rollback", harness.rollback)
+        event.remove(engine, "commit", harness.commit)
+        event.remove(engine, "rollback_savepoint", harness.rollback_savepoint)
+        event.remove(engine, "rollback_twophase", harness.rollback_twophase)
+        event.remove(engine, "commit_twophase", harness.commit_twophase)
+
+
+class ResetAgentTest(ResetFixture, fixtures.TestBase):
+    # many of these tests illustate rollback-on-return being redundant
+    # vs. what the transaction just did, however this is to ensure
+    # even if statements were invoked on the DBAPI connection directly,
+    # the state is cleared.    options to optimize this with clear
+    # docs etc. should be added.
+
+    __backend__ = True
+
+    def test_begin_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [mock.call.rollback(connection), mock.call.do_rollback(mock.ANY)],
+        )
+
+    def test_begin_rollback(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans.rollback()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    def test_begin_commit(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans.commit()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.commit(connection),
+                mock.call.do_commit(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    def test_trans_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans.close()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_nested_trans_close_one(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            t1 = connection.begin()
+            t2 = connection.begin_nested()
+            assert connection._nested_transaction is t2
+            assert connection._transaction is t1
+            t2.close()
+            assert connection._nested_transaction is None
+            assert connection._transaction is t1
+            t1.close()
+        assert not t1.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback_savepoint(connection, mock.ANY, mock.ANY),
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_nested_trans_close_two(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            t1 = connection.begin()
+            t2 = connection.begin_nested()
+            assert connection._nested_transaction is t2
+            assert connection._transaction is t1
+
+            t1.close()
+
+            assert connection._nested_transaction is None
+            assert connection._transaction is None
+
+        assert not t1.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_nested_trans_rollback(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            t1 = connection.begin()
+            t2 = connection.begin_nested()
+            assert connection._nested_transaction is t2
+            assert connection._transaction is t1
+            t2.close()
+            assert connection._nested_transaction is None
+            assert connection._transaction is t1
+            t1.rollback()
+            assert connection._transaction is None
+        assert not t2.is_active
+        assert not t1.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback_savepoint(connection, mock.ANY, mock.ANY),
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_nested_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            with testing.expect_deprecated_20(
+                r"Calling Connection.begin_nested\(\) in "
+                r"2.0 style use will return"
+            ):
+                trans = connection.begin_nested()
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_begin_nested_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans2 = connection.begin_nested()
+        assert not trans2.is_active
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_begin_nested_rollback_commit(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans2 = connection.begin_nested()
+            trans2.rollback()
+            trans.commit()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback_savepoint(connection, mock.ANY, mock.ANY),
+                mock.call.commit(connection),
+                mock.call.do_commit(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_begin_nested_rollback_rollback(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans2 = connection.begin_nested()
+            trans2.rollback()
+            trans.rollback()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback_savepoint(connection, mock.ANY, mock.ANY),
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+
+class FutureResetAgentTest(
+    ResetFixture, fixtures.FutureEngineMixin, fixtures.TestBase
+):
+
+    __backend__ = True
+
+    def test_reset_agent_no_conn_transaction(self, reset_agent):
+        with reset_agent.engine.connect():
+            pass
+
+        eq_(reset_agent.mock_calls, [mock.call.do_rollback(mock.ANY)])
+
+    def test_begin_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [mock.call.rollback(connection), mock.call.do_rollback(mock.ANY)],
+        )
+
+    def test_begin_rollback(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans.rollback()
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    def test_begin_commit(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans.commit()
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.commit(connection),
+                mock.call.do_commit(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_nested_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin_nested()
+        # it's a savepoint, but root made sure it closed
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [mock.call.rollback(connection), mock.call.do_rollback(mock.ANY)],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_begin_nested_close(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans2 = connection.begin_nested()
+        assert not trans2.is_active
+        assert not trans.is_active
+        eq_(
+            reset_agent.mock_calls,
+            [mock.call.rollback(connection), mock.call.do_rollback(mock.ANY)],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_begin_nested_rollback_commit(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans2 = connection.begin_nested()
+            trans2.rollback()  # this is not a connection level event
+            trans.commit()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback_savepoint(connection, mock.ANY, None),
+                mock.call.commit(connection),
+                mock.call.do_commit(mock.ANY),
+                mock.call.do_rollback(mock.ANY),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_begin_begin_nested_rollback_rollback(self, reset_agent):
+        with reset_agent.engine.connect() as connection:
+            trans = connection.begin()
+            trans2 = connection.begin_nested()
+            trans2.rollback()
+            trans.rollback()
+        eq_(
+            reset_agent.mock_calls,
+            [
+                mock.call.rollback_savepoint(connection, mock.ANY, mock.ANY),
+                mock.call.rollback(connection),
+                mock.call.do_rollback(mock.ANY),
+                mock.call.do_rollback(mock.ANY),  # this is the reset on return
+            ],
+        )
+
+
+class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
+    __backend__ = True
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "users",
+            metadata,
+            Column("user_id", INT, primary_key=True, autoincrement=False),
+            Column("user_name", VARCHAR(20)),
+            test_needs_acid=True,
+        )
+        Table(
+            "users_autoinc",
+            metadata,
+            Column(
+                "user_id", INT, primary_key=True, test_needs_autoincrement=True
+            ),
+            Column("user_name", VARCHAR(20)),
+            test_needs_acid=True,
+        )
+
+    @testing.fixture
+    def local_connection(self):
+        with testing.db.connect() as conn:
+            yield conn
+
+    def test_interrupt_ctxmanager_engine(self, trans_ctx_manager_fixture):
+        fn = trans_ctx_manager_fixture
+
+        fn(testing.db, trans_on_subject=False, execute_on_subject=False)
+
+    @testing.combinations((True,), (False,), argnames="trans_on_subject")
+    def test_interrupt_ctxmanager_connection(
+        self, trans_ctx_manager_fixture, trans_on_subject
+    ):
+        fn = trans_ctx_manager_fixture
+
+        with testing.db.connect() as conn:
+            fn(
+                conn,
+                trans_on_subject=trans_on_subject,
+                execute_on_subject=True,
+            )
+
+    def test_autobegin_rollback(self):
+        users = self.tables.users
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+            conn.rollback()
+
+            eq_(conn.scalar(select(func.count(1)).select_from(users)), 0)
+
+    @testing.requires.autocommit
+    def test_autocommit_isolation_level(self):
+        users = self.tables.users
+
+        with testing.db.connect().execution_options(
+            isolation_level="AUTOCOMMIT"
+        ) as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+            conn.rollback()
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    @testing.requires.autocommit
+    def test_no_autocommit_w_begin(self):
+
+        with testing.db.begin() as conn:
+            assert_raises_message(
+                exc.InvalidRequestError,
+                "This connection has already begun a transaction; "
+                "isolation_level may not be altered until transaction end",
+                conn.execution_options,
+                isolation_level="AUTOCOMMIT",
+            )
+
+    @testing.requires.autocommit
+    def test_no_autocommit_w_autobegin(self):
+
+        with testing.db.connect() as conn:
+            conn.execute(select(1))
+
+            assert_raises_message(
+                exc.InvalidRequestError,
+                "This connection has already begun a transaction; "
+                "isolation_level may not be altered until transaction end",
+                conn.execution_options,
+                isolation_level="AUTOCOMMIT",
+            )
+
+            conn.rollback()
+
+            conn.execution_options(isolation_level="AUTOCOMMIT")
+
+    def test_autobegin_commit(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+
+            assert not conn.in_transaction()
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            assert conn.in_transaction()
+            conn.commit()
+
+            assert not conn.in_transaction()
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name 2"})
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                2,
+            )
+
+            assert conn.in_transaction()
+            conn.rollback()
+            assert not conn.in_transaction()
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    def test_rollback_on_close(self):
+        canary = mock.Mock()
+        with testing.db.connect() as conn:
+            event.listen(conn, "rollback", canary)
+            conn.execute(select(1))
+            assert conn.in_transaction()
+
+        eq_(canary.mock_calls, [mock.call(conn)])
+
+    def test_no_on_close_no_transaction(self):
+        canary = mock.Mock()
+        with testing.db.connect() as conn:
+            event.listen(conn, "rollback", canary)
+            conn.execute(select(1))
+            conn.rollback()
+            assert not conn.in_transaction()
+
+        eq_(canary.mock_calls, [mock.call(conn)])
+
+    def test_rollback_on_exception(self):
+        canary = mock.Mock()
+        try:
+            with testing.db.connect() as conn:
+                event.listen(conn, "rollback", canary)
+                conn.execute(select(1))
+                assert conn.in_transaction()
+                raise Exception("some error")
+            assert False
+        except:
+            pass
+
+        eq_(canary.mock_calls, [mock.call(conn)])
+
+    def test_rollback_on_exception_if_no_trans(self):
+        canary = mock.Mock()
+        try:
+            with testing.db.connect() as conn:
+                event.listen(conn, "rollback", canary)
+                assert not conn.in_transaction()
+                raise Exception("some error")
+            assert False
+        except:
+            pass
+
+        eq_(canary.mock_calls, [])
+
+    def test_commit_no_begin(self):
+        with testing.db.connect() as conn:
+            assert not conn.in_transaction()
+            conn.commit()
+
+    @testing.requires.independent_connections
+    def test_commit_inactive(self):
+        with testing.db.connect() as conn:
+            conn.begin()
+            conn.invalidate()
+
+            assert_raises_message(
+                exc.InvalidRequestError, "Can't reconnect until", conn.commit
+            )
+
+    @testing.requires.independent_connections
+    def test_rollback_inactive(self):
+        users = self.tables.users
+        with testing.db.connect() as conn:
+
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+            conn.commit()
+
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            conn.invalidate()
+
+            assert_raises_message(
+                exc.PendingRollbackError,
+                "Can't reconnect",
+                conn.execute,
+                select(1),
+            )
+
+            conn.rollback()
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    def test_rollback_no_begin(self):
+        with testing.db.connect() as conn:
+            assert not conn.in_transaction()
+            conn.rollback()
+
+    def test_rollback_end_ctx_manager(self):
+        with testing.db.begin() as conn:
+            assert conn.in_transaction()
+            conn.rollback()
+            assert not conn.in_transaction()
+
+    def test_rollback_end_ctx_manager_autobegin(self, local_connection):
+        m1 = mock.Mock()
+
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+
+        with local_connection.begin() as trans:
+            assert local_connection.in_transaction()
+            trans.rollback()
+            assert not local_connection.in_transaction()
+
+            # previously, would be subject to autocommit.
+            # now it raises
+            with expect_raises_message(
+                exc.InvalidRequestError,
+                "Can't operate on closed transaction inside context manager.  "
+                "Please complete the context manager before emitting "
+                "further commands.",
+            ):
+                local_connection.execute(select(1))
+
+            assert not local_connection.in_transaction()
+
+    @testing.combinations((True,), (False,), argnames="roll_back_in_block")
+    def test_ctxmanager_rolls_back(self, local_connection, roll_back_in_block):
+        m1 = mock.Mock()
+
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+
+        with expect_raises_message(Exception, "test"):
+            with local_connection.begin() as trans:
+                if roll_back_in_block:
+                    trans.rollback()
+
+                if 1 == 1:
+                    raise Exception("test")
+
+        assert not trans.is_active
+        assert not local_connection.in_transaction()
+        assert trans._deactivated_from_connection
+
+        eq_(m1.mock_calls, [mock.call.rollback(local_connection)])
+
+    @testing.requires.savepoints
+    def test_ctxmanager_autobegins_real_trans_from_nested(
+        self, local_connection
+    ):
+        m1 = mock.Mock()
+
+        event.listen(
+            local_connection, "rollback_savepoint", m1.rollback_savepoint
+        )
+        event.listen(
+            local_connection, "release_savepoint", m1.release_savepoint
+        )
+        event.listen(local_connection, "rollback", m1.rollback)
+        event.listen(local_connection, "commit", m1.commit)
+        event.listen(local_connection, "begin", m1.begin)
+        event.listen(local_connection, "savepoint", m1.savepoint)
+
+        with local_connection.begin_nested() as nested_trans:
+            pass
+
+        assert not nested_trans.is_active
+        assert nested_trans._deactivated_from_connection
+        # legacy mode, no savepoint at all
+        eq_(
+            m1.mock_calls,
+            [
+                mock.call.begin(local_connection),
+                mock.call.savepoint(local_connection, mock.ANY),
+                mock.call.release_savepoint(
+                    local_connection, mock.ANY, mock.ANY
+                ),
+            ],
+        )
+
+    def test_explicit_begin(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            assert not conn.in_transaction()
+            conn.begin()
+            assert conn.in_transaction()
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+            conn.commit()
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    def test_no_double_begin(self):
+        with testing.db.connect() as conn:
+            conn.begin()
+
+            assert_raises_message(
+                exc.InvalidRequestError,
+                "a transaction is already begun for this connection",
+                conn.begin,
+            )
+
+    def test_no_autocommit(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                0,
+            )
+
+    def test_begin_block(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_one(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            savepoint = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                2,
+            )
+            savepoint.rollback()
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_two(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            savepoint = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                2,
+            )
+            savepoint.commit()
+
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                2,
+            )
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                2,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_three(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            conn.rollback()
+
+            assert not conn.in_transaction()
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                0,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_four(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            sp1 = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            sp2 = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 3, "user_name": "name3"})
+
+            sp2.rollback()
+
+            assert not sp2.is_active
+            assert sp1.is_active
+            assert conn.in_transaction()
+
+        assert not sp1.is_active
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                2,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_five(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            sp2 = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 3, "user_name": "name3"})
+
+            sp2.commit()
+
+            assert conn.in_transaction()
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                3,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_six(self):
+        users = self.tables.users
+
+        with testing.db.begin() as conn:
+            conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+            sp1 = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+            assert conn._nested_transaction is sp1
+
+            sp2 = conn.begin_nested()
+            conn.execute(users.insert(), {"user_id": 3, "user_name": "name3"})
+
+            assert conn._nested_transaction is sp2
+
+            sp2.commit()
+
+            assert conn._nested_transaction is sp1
+
+            sp1.rollback()
+
+            assert conn._nested_transaction is None
+
+            assert conn.in_transaction()
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                1,
+            )
+
+    @testing.requires.savepoints
+    def test_savepoint_seven(self):
+        users = self.tables.users
+
+        conn = testing.db.connect()
+        trans = conn.begin()
+        conn.execute(users.insert(), {"user_id": 1, "user_name": "name"})
+
+        sp1 = conn.begin_nested()
+        conn.execute(users.insert(), {"user_id": 2, "user_name": "name2"})
+
+        sp2 = conn.begin_nested()
+        conn.execute(users.insert(), {"user_id": 3, "user_name": "name3"})
+
+        assert conn.in_transaction()
+
+        trans.close()
+
+        assert not sp1.is_active
+        assert not sp2.is_active
+        assert not trans.is_active
+        assert conn._transaction is None
+        assert conn._nested_transaction is None
+
+        with testing.db.connect() as conn:
+            eq_(
+                conn.scalar(select(func.count(1)).select_from(users)),
+                0,
+            )

--- a/test/test_engin_transaction.py
+++ b/test/test_engin_transaction.py
@@ -1445,7 +1445,7 @@ class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
                 assert conn.in_transaction()
                 raise Exception("some error")
             assert False
-        except:
+        except Exception:
             pass
 
         eq_(canary.mock_calls, [mock.call(conn)])
@@ -1458,7 +1458,7 @@ class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
                 assert not conn.in_transaction()
                 raise Exception("some error")
             assert False
-        except:
+        except Exception:
             pass
 
         eq_(canary.mock_calls, [])

--- a/test/test_orm_transaction.py
+++ b/test/test_orm_transaction.py
@@ -1044,7 +1044,7 @@ def subtransaction_recipe_one(self):
 
         try:
             yield
-        except:
+        except Exception:
             if session.in_transaction():
                 session.rollback()
             raise
@@ -1075,7 +1075,7 @@ def subtransaction_recipe_three(self):
             session.begin()
             try:
                 yield
-            except:
+            except Exception:
                 if session.in_transaction():
                     session.rollback()
             else:
@@ -1083,7 +1083,7 @@ def subtransaction_recipe_three(self):
         else:
             try:
                 yield
-            except:
+            except Exception:
                 if session.in_transaction():
                     session.rollback()
                 raise
@@ -1236,7 +1236,7 @@ class SubtransactionRecipeTest(FixtureTest):
                     sess.add(User(name="u1"))
                     sess.flush()
                     raise Exception("force rollback")
-            except:
+            except Exception:
                 pass
 
             if self.recipe_rollsback_early:
@@ -1258,7 +1258,7 @@ class SubtransactionRecipeTest(FixtureTest):
                     with subtransaction_recipe(sess):
                         assert sess._legacy_transaction()
                         raise Exception("force rollback")
-                except:
+                except Exception:
                     pass
 
                 if self.recipe_rollsback_early:
@@ -2189,7 +2189,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 )
 
                 raise Exception("force rollback")
-        except:
+        except Exception:
             pass
         is_not(sess._legacy_transaction(), None)
 
@@ -2205,7 +2205,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 )
 
                 raise Exception("force rollback")
-        except:
+        except Exception:
             pass
         is_(sess._legacy_transaction(), None)
 
@@ -2261,7 +2261,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                     )
 
                     raise Exception("force rollback")
-        except:
+        except Exception:
             pass
 
         # rolled back
@@ -2284,7 +2284,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                     )
 
                 raise Exception("force rollback")
-        except:
+        except Exception:
             pass
 
         # committed
@@ -2308,7 +2308,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 )
 
                 raise Exception("force rollback")
-        except:
+        except Exception:
             pass
 
         # rolled back
@@ -2332,7 +2332,7 @@ class ContextManagerPlusFutureTest(FixtureTest):
                 )
 
             raise Exception("force rollback")
-        except:
+        except Exception:
             pass
 
         # committed

--- a/test/test_orm_transaction.py
+++ b/test/test_orm_transaction.py
@@ -717,6 +717,7 @@ class SessionTransactionTest(fixtures.RemovesEvents, FixtureTest):
             sess.rollback,
         )
 
+    @testing.requires.savepoints
     @testing.requires.independent_connections
     @testing.emits_warning(".*previous exception")
     def test_failed_rollback_deactivates_transaction(self):

--- a/test/test_orm_transaction.py
+++ b/test/test_orm_transaction.py
@@ -1,0 +1,2891 @@
+import contextlib
+
+from sqlalchemy import Column
+from sqlalchemy import event
+from sqlalchemy import exc as sa_exc
+from sqlalchemy import func
+from sqlalchemy import inspect
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import select
+from sqlalchemy import String
+from sqlalchemy import Table
+from sqlalchemy import testing
+from sqlalchemy import text
+from sqlalchemy.future import Engine
+from sqlalchemy.orm import attributes
+from sqlalchemy.orm import exc as orm_exc
+from sqlalchemy.orm import mapper
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import session as _session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.util import identity_key
+from sqlalchemy.sql import elements
+from sqlalchemy.testing import assert_raises
+from sqlalchemy.testing import assert_raises_message
+from sqlalchemy.testing import assert_warnings
+from sqlalchemy.testing import engines
+from sqlalchemy.testing import eq_
+from sqlalchemy.testing import expect_raises_message
+from sqlalchemy.testing import expect_warnings
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing import is_
+from sqlalchemy.testing import is_not
+from sqlalchemy.testing import mock
+from sqlalchemy.testing.fixtures import fixture_session
+from sqlalchemy.testing.util import gc_collect
+from test._orm_fixtures import FixtureTest
+
+
+class SessionTransactionTest(fixtures.RemovesEvents, FixtureTest):
+    run_inserts = None
+    __backend__ = True
+
+    @testing.fixture
+    def conn(self):
+        with testing.db.connect() as conn:
+            yield conn
+
+    @testing.fixture
+    def future_conn(self):
+
+        engine = Engine._future_facade(testing.db)
+        with engine.connect() as conn:
+            yield conn
+
+    def test_no_close_transaction_on_flush(self, conn):
+        User, users = self.classes.User, self.tables.users
+
+        c = conn
+        mapper(User, users)
+        s = Session(bind=c)
+        s.begin()
+        tran = s._legacy_transaction()
+        s.add(User(name="first"))
+        s.flush()
+        c.exec_driver_sql("select * from users")
+        u = User(name="two")
+        s.add(u)
+        s.flush()
+        u = User(name="third")
+        s.add(u)
+        s.flush()
+        assert s._legacy_transaction() is tran
+        tran.close()
+
+    def test_subtransaction_on_external_subtrans(self, conn):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        trans = conn.begin()
+        sess = Session(bind=conn, autocommit=False, autoflush=True)
+        sess.begin(subtransactions=True)
+        u = User(name="ed")
+        sess.add(u)
+        sess.flush()
+        sess.commit()  # commit does nothing
+        trans.rollback()  # rolls back
+        assert len(sess.query(User).all()) == 0
+        sess.close()
+
+    def test_subtransaction_on_external_no_begin(self, conn):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        trans = conn.begin()
+        sess = Session(bind=conn, autocommit=False, autoflush=True)
+        u = User(name="ed")
+        sess.add(u)
+        sess.flush()
+        sess.commit()  # commit does nothing
+        trans.rollback()  # rolls back
+        assert len(sess.query(User).all()) == 0
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_external_nested_transaction(self, conn):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        trans = conn.begin()
+        sess = Session(bind=conn, autocommit=False, autoflush=True)
+        u1 = User(name="u1")
+        sess.add(u1)
+        sess.flush()
+
+        savepoint = sess.begin_nested()
+        u2 = User(name="u2")
+        sess.add(u2)
+        sess.flush()
+        savepoint.rollback()
+
+        trans.commit()
+        assert len(sess.query(User).all()) == 1
+
+    def test_subtransaction_on_external_commit_future(self, future_conn):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        conn = future_conn
+        conn.begin()
+
+        sess = Session(bind=conn, autocommit=False, autoflush=True)
+        u = User(name="ed")
+        sess.add(u)
+        sess.flush()
+        sess.commit()  # commit does nothing
+        conn.rollback()  # rolls back
+        assert len(sess.query(User).all()) == 0
+        sess.close()
+
+    def test_subtransaction_on_external_rollback_future(self, future_conn):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        conn = future_conn
+        conn.begin()
+
+        sess = Session(bind=conn, autocommit=False, autoflush=True)
+        u = User(name="ed")
+        sess.add(u)
+        sess.flush()
+        sess.rollback()  # rolls back
+        conn.commit()  # nothing to commit
+        assert len(sess.query(User).all()) == 0
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_savepoint_on_external_future(self, future_conn):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        conn = future_conn
+        conn.begin()
+        sess = Session(bind=conn, autocommit=False, autoflush=True)
+        u1 = User(name="u1")
+        sess.add(u1)
+        sess.flush()
+
+        sess.begin_nested()
+        u2 = User(name="u2")
+        sess.add(u2)
+        sess.flush()
+        sess.rollback()
+
+        conn.commit()
+        assert len(sess.query(User).all()) == 1
+
+    @testing.requires.savepoints
+    def test_nested_accounting_new_items_removed(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+
+        session = fixture_session()
+        session.begin()
+        session.begin_nested()
+        u1 = User(name="u1")
+        session.add(u1)
+        session.commit()
+        assert u1 in session
+        session.rollback()
+        assert u1 not in session
+
+    @testing.requires.savepoints
+    def test_nested_accounting_deleted_items_restored(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+
+        session = fixture_session()
+        session.begin()
+        u1 = User(name="u1")
+        session.add(u1)
+        session.commit()
+
+        session.begin()
+        u1 = session.query(User).first()
+
+        session.begin_nested()
+        session.delete(u1)
+        session.commit()
+        assert u1 not in session
+        session.rollback()
+        assert u1 in session
+
+    @testing.requires.savepoints
+    def test_heavy_nesting(self):
+        users = self.tables.users
+
+        session = fixture_session()
+        session.begin()
+        session.connection().execute(users.insert().values(name="user1"))
+        session.begin(subtransactions=True)
+        session.begin_nested()
+        session.connection().execute(users.insert().values(name="user2"))
+        assert (
+            session.connection()
+            .exec_driver_sql("select count(1) from users")
+            .scalar()
+            == 2
+        )
+        session.rollback()
+        assert (
+            session.connection()
+            .exec_driver_sql("select count(1) from users")
+            .scalar()
+            == 1
+        )
+        session.connection().execute(users.insert().values(name="user3"))
+        session.commit()
+        assert (
+            session.connection()
+            .exec_driver_sql("select count(1) from users")
+            .scalar()
+            == 2
+        )
+
+    @testing.requires.savepoints
+    def test_heavy_nesting_future(self):
+        users = self.tables.users
+
+        engine = Engine._future_facade(testing.db)
+        with Session(engine, autocommit=False) as session:
+            session.begin()
+            session.connection().execute(users.insert().values(name="user1"))
+            session.begin(subtransactions=True)
+            session.begin_nested()
+            session.connection().execute(users.insert().values(name="user2"))
+            assert (
+                session.connection()
+                .exec_driver_sql("select count(1) from users")
+                .scalar()
+                == 2
+            )
+            session.rollback()
+            assert (
+                session.connection()
+                .exec_driver_sql("select count(1) from users")
+                .scalar()
+                == 1
+            )
+            session.connection().execute(users.insert().values(name="user3"))
+            session.commit()
+            assert (
+                session.connection()
+                .exec_driver_sql("select count(1) from users")
+                .scalar()
+                == 2
+            )
+
+    @testing.requires.savepoints
+    def test_dirty_state_transferred_deep_nesting(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+
+        with fixture_session() as s:
+            u1 = User(name="u1")
+            s.add(u1)
+            s.commit()
+
+            nt1 = s.begin_nested()
+            nt2 = s.begin_nested()
+            u1.name = "u2"
+            assert attributes.instance_state(u1) not in nt2._dirty
+            assert attributes.instance_state(u1) not in nt1._dirty
+            s.flush()
+            assert attributes.instance_state(u1) in nt2._dirty
+            assert attributes.instance_state(u1) not in nt1._dirty
+
+            s.commit()
+            assert attributes.instance_state(u1) in nt2._dirty
+            assert attributes.instance_state(u1) in nt1._dirty
+
+            s.rollback()
+            assert attributes.instance_state(u1).expired
+            eq_(u1.name, "u1")
+
+    @testing.requires.savepoints
+    def test_dirty_state_transferred_deep_nesting_future(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+
+        with fixture_session(future=True) as s:
+            u1 = User(name="u1")
+            s.add(u1)
+            s.commit()
+
+            nt1 = s.begin_nested()
+            nt2 = s.begin_nested()
+            u1.name = "u2"
+            assert attributes.instance_state(u1) not in nt2._dirty
+            assert attributes.instance_state(u1) not in nt1._dirty
+            s.flush()
+            assert attributes.instance_state(u1) in nt2._dirty
+            assert attributes.instance_state(u1) not in nt1._dirty
+
+            nt2.commit()
+            assert attributes.instance_state(u1) in nt2._dirty
+            assert attributes.instance_state(u1) in nt1._dirty
+
+            nt1.rollback()
+            assert attributes.instance_state(u1).expired
+            eq_(u1.name, "u1")
+
+    @testing.requires.independent_connections
+    def test_transactions_isolated(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+
+        s1 = fixture_session(autocommit=False)
+        s2 = fixture_session(autocommit=False)
+        u1 = User(name="u1")
+        s1.add(u1)
+        s1.flush()
+
+        assert s2.query(User).all() == []
+
+    @testing.requires.independent_connections
+    def test_invalidate(self):
+        User, users = self.classes.User, self.tables.users
+        mapper(User, users)
+        sess = fixture_session()
+        u = User(name="u1")
+        sess.add(u)
+        sess.flush()
+        c1 = sess.connection(bind_arguments={"mapper": User})
+        dbapi_conn = c1.connection
+        assert dbapi_conn.is_valid
+
+        sess.invalidate()
+
+        # Connection object is closed
+        assert c1.closed
+
+        # "invalidated" is not part of "closed" state
+        assert not c1.invalidated
+
+        # but the DBAPI conn (really ConnectionFairy)
+        # is invalidated
+        assert not dbapi_conn.is_valid
+
+        eq_(sess.query(User).all(), [])
+        c2 = sess.connection(bind_arguments={"mapper": User})
+        assert not c2.invalidated
+        assert c2.connection.is_valid
+
+    def test_subtransaction_on_noautocommit(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        sess = fixture_session(autocommit=False, autoflush=True)
+        sess.begin(subtransactions=True)
+        u = User(name="u1")
+        sess.add(u)
+        sess.flush()
+        sess.commit()  # commit does nothing
+        sess.rollback()  # rolls back
+        assert len(sess.query(User).all()) == 0
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_nested_transaction(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        sess = fixture_session()
+        sess.begin()
+
+        u = User(name="u1")
+        sess.add(u)
+        sess.flush()
+
+        sess.begin_nested()  # nested transaction
+
+        u2 = User(name="u2")
+        sess.add(u2)
+        sess.flush()
+
+        sess.rollback()
+
+        sess.commit()
+        assert len(sess.query(User).all()) == 1
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_nested_autotrans(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        sess = fixture_session(autocommit=False)
+        u = User(name="u1")
+        sess.add(u)
+        sess.flush()
+
+        sess.begin_nested()  # nested transaction
+
+        u2 = User(name="u2")
+        sess.add(u2)
+        sess.flush()
+
+        sess.rollback()  # rolls back nested only
+
+        sess.commit()
+        assert len(sess.query(User).all()) == 1
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_nested_autotrans_future(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        sess = fixture_session(autocommit=False, future=True)
+        u = User(name="u1")
+        sess.add(u)
+        sess.flush()
+
+        sess.begin_nested()  # nested transaction
+
+        u2 = User(name="u2")
+        sess.add(u2)
+        sess.flush()
+
+        sess.rollback()  # rolls back the whole trans
+
+        sess.commit()
+        assert len(sess.query(User).all()) == 0
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_nested_transaction_connection_add(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        sess = fixture_session(autocommit=True)
+
+        sess.begin()
+        sess.begin_nested()
+
+        u1 = User(name="u1")
+        sess.add(u1)
+        sess.flush()
+
+        sess.rollback()
+
+        u2 = User(name="u2")
+        sess.add(u2)
+
+        sess.commit()
+
+        eq_(set(sess.query(User).all()), set([u2]))
+
+        sess.begin()
+        sess.begin_nested()
+
+        u3 = User(name="u3")
+        sess.add(u3)
+        sess.commit()  # commit the nested transaction
+        sess.rollback()
+
+        eq_(set(sess.query(User).all()), set([u2]))
+
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_mixed_transaction_control(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        sess = fixture_session(autocommit=True)
+
+        sess.begin()
+        sess.begin_nested()
+        transaction = sess.begin(subtransactions=True)
+
+        sess.add(User(name="u1"))
+
+        transaction.commit()
+        sess.commit()
+        sess.commit()
+
+        sess.close()
+
+        eq_(len(sess.query(User).all()), 1)
+
+        t1 = sess.begin()
+        t2 = sess.begin_nested()
+
+        sess.add(User(name="u2"))
+
+        t2.commit()
+        assert sess._legacy_transaction() is t1
+
+        sess.close()
+
+    @testing.requires.savepoints
+    def test_mixed_transaction_close(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        sess = fixture_session(autocommit=False)
+
+        sess.begin_nested()
+
+        sess.add(User(name="u1"))
+        sess.flush()
+
+        sess.close()
+
+        sess.add(User(name="u2"))
+        sess.commit()
+
+        sess.close()
+
+        eq_(len(sess.query(User).all()), 1)
+
+    def test_begin_fails_connection_is_closed(self):
+        eng = engines.testing_engine()
+
+        state = []
+
+        @event.listens_for(eng, "begin")
+        def do_begin(conn):
+            state.append((conn, conn.connection))
+            raise Exception("failure")
+
+        s1 = Session(eng)
+
+        assert_raises_message(
+            Exception, "failure", s1.execute, text("select 1")
+        )
+
+        conn, fairy = state[0]
+        assert not fairy.is_valid
+        assert conn.closed
+        assert not conn.invalidated
+
+        s1.close()
+
+        # close does not occur because references were not saved, however
+        # the underlying DBAPI connection was closed
+        assert not fairy.is_valid
+        assert conn.closed
+        assert not conn.invalidated
+
+    def test_begin_savepoint_fails_connection_is_not_closed(self):
+        eng = engines.testing_engine()
+
+        state = []
+
+        @event.listens_for(eng, "savepoint")
+        def do_begin(conn, name):
+            state.append((conn, conn.connection))
+            raise Exception("failure")
+
+        s1 = Session(eng)
+
+        s1.begin_nested()
+        assert_raises_message(
+            Exception, "failure", s1.execute, text("select 1")
+        )
+
+        conn, fairy = state[0]
+        assert fairy.is_valid
+        assert not conn.closed
+        assert not conn.invalidated
+
+        s1.close()
+
+        assert conn.closed
+        assert not fairy.is_valid
+
+    def test_continue_flushing_on_commit(self):
+        """test that post-flush actions get flushed also if
+        we're in commit()"""
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        sess = fixture_session()
+
+        to_flush = [User(name="ed"), User(name="jack"), User(name="wendy")]
+
+        @event.listens_for(sess, "after_flush_postexec")
+        def add_another_user(session, ctx):
+            if to_flush:
+                session.add(to_flush.pop(0))
+
+        x = [1]
+
+        @event.listens_for(sess, "after_commit")  # noqa
+        def add_another_user(session):  # noqa
+            x[0] += 1
+
+        sess.add(to_flush.pop())
+        sess.commit()
+        eq_(x, [2])
+        eq_(sess.scalar(select(func.count(users.c.id))), 3)
+
+    def test_continue_flushing_guard(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        sess = fixture_session()
+
+        @event.listens_for(sess, "after_flush_postexec")
+        def add_another_user(session, ctx):
+            session.add(User(name="x"))
+
+        sess.add(User(name="x"))
+        assert_raises_message(
+            orm_exc.FlushError,
+            "Over 100 subsequent flushes have occurred",
+            sess.commit,
+        )
+
+    def test_error_on_using_inactive_session_commands(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        sess = fixture_session(autocommit=True)
+        sess.begin()
+        sess.begin(subtransactions=True)
+        sess.add(User(name="u1"))
+        sess.flush()
+        sess.rollback()
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "This session is in 'inactive' state, due to the SQL transaction "
+            "being rolled back; no further SQL can be emitted within this "
+            "transaction.",
+            sess.begin,
+            subtransactions=True,
+        )
+        sess.close()
+
+    def test_no_sql_during_commit(self):
+        sess = fixture_session(autocommit=False)
+
+        @event.listens_for(sess, "after_commit")
+        def go(session):
+            session.execute(text("select 1"))
+
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "This session is in 'committed' state; no further "
+            "SQL can be emitted within this transaction.",
+            sess.commit,
+        )
+
+    def test_no_sql_during_prepare(self):
+        sess = fixture_session(autocommit=False, twophase=True)
+
+        sess.prepare()
+
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "This session is in 'prepared' state; no further "
+            "SQL can be emitted within this transaction.",
+            sess.execute,
+            text("select 1"),
+        )
+
+    def test_no_sql_during_rollback(self):
+        sess = fixture_session(autocommit=False)
+
+        sess.connection()
+
+        @event.listens_for(sess, "after_rollback")
+        def go(session):
+            session.execute(text("select 1"))
+
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "This session is in 'inactive' state, due to the SQL transaction "
+            "being rolled back; no further SQL can be emitted within this "
+            "transaction.",
+            sess.rollback,
+        )
+
+    @testing.requires.independent_connections
+    @testing.emits_warning(".*previous exception")
+    def test_failed_rollback_deactivates_transaction(self):
+        # test #4050
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        session = Session(bind=testing.db)
+
+        rollback_error = testing.db.dialect.dbapi.InterfaceError(
+            "Can't roll back to savepoint"
+        )
+
+        def prevent_savepoint_rollback(
+            cursor, statement, parameters, context=None
+        ):
+            if (
+                context is not None
+                and context.compiled
+                and isinstance(
+                    context.compiled.statement,
+                    elements.RollbackToSavepointClause,
+                )
+            ):
+                raise rollback_error
+
+        self.event_listen(
+            testing.db.dialect, "do_execute", prevent_savepoint_rollback
+        )
+
+        with session.begin():
+            session.add(User(id=1, name="x"))
+
+        session.begin_nested()
+        # raises IntegrityError on flush
+        session.add(User(id=1, name="x"))
+        assert_raises_message(
+            sa_exc.InterfaceError,
+            "Can't roll back to savepoint",
+            session.commit,
+        )
+
+        # rollback succeeds, because the Session is deactivated
+        eq_(session._transaction._state, _session.DEACTIVE)
+        eq_(session.is_active, False)
+        session.rollback()
+
+        # back to normal
+        eq_(session._transaction._state, _session.ACTIVE)
+        eq_(session.is_active, True)
+
+        trans = session._transaction
+
+        # leave the outermost trans
+        session.rollback()
+
+        # trans is now closed
+        eq_(trans._state, _session.CLOSED)
+
+        # outermost transaction is new
+        is_not(session._transaction, trans)
+
+        is_(session._transaction, None)
+        eq_(session.is_active, True)
+
+    def test_no_prepare_wo_twophase(self):
+        sess = fixture_session(autocommit=False)
+
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "'twophase' mode not enabled, or not root "
+            "transaction; can't prepare.",
+            sess.prepare,
+        )
+
+    def test_closed_status_check(self):
+        sess = fixture_session()
+        trans = sess.begin()
+        trans.rollback()
+        assert_raises_message(
+            sa_exc.ResourceClosedError,
+            "This transaction is closed",
+            trans.rollback,
+        )
+        assert_raises_message(
+            sa_exc.ResourceClosedError,
+            "This transaction is closed",
+            trans.commit,
+        )
+
+    def test_deactive_status_check(self):
+        sess = fixture_session()
+        trans = sess.begin()
+        trans2 = sess.begin(subtransactions=True)
+        trans2.rollback()
+        assert_raises_message(
+            sa_exc.InvalidRequestError,
+            "This session is in 'inactive' state, due to the SQL transaction "
+            "being rolled back; no further SQL can be emitted within this "
+            "transaction.",
+            trans.commit,
+        )
+
+    def test_deactive_status_check_w_exception(self):
+        sess = fixture_session()
+        trans = sess.begin()
+        trans2 = sess.begin(subtransactions=True)
+        try:
+            raise Exception("test")
+        except Exception:
+            trans2.rollback(_capture_exception=True)
+        assert_raises_message(
+            sa_exc.PendingRollbackError,
+            r"This Session's transaction has been rolled back due to a "
+            r"previous exception during flush. To begin a new transaction "
+            r"with this Session, first issue Session.rollback\(\). "
+            r"Original exception was: test",
+            trans.commit,
+        )
+
+    def _inactive_flushed_session_fixture(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        sess = fixture_session()
+        u1 = User(id=1, name="u1")
+        sess.add(u1)
+        sess.commit()
+
+        sess.add(User(id=1, name="u2"))
+
+        with expect_warnings("New instance"):
+            assert_raises(sa_exc.IntegrityError, sess.flush)
+        return sess, u1
+
+    def test_execution_options_begin_transaction(self):
+        bind = mock.Mock(
+            connect=mock.Mock(
+                return_value=mock.Mock(
+                    _is_future=False,
+                    execution_options=mock.Mock(
+                        return_value=mock.Mock(_is_future=False)
+                    ),
+                )
+            )
+        )
+
+        sess = Session(bind=bind)
+        c1 = sess.connection(execution_options={"isolation_level": "FOO"})
+        eq_(bind.mock_calls, [mock.call.connect()])
+        eq_(
+            bind.connect().mock_calls,
+            [mock.call.execution_options(isolation_level="FOO")],
+        )
+
+        eq_(c1, bind.connect().execution_options())
+
+    def test_execution_options_ignored_mid_transaction(self):
+        bind = mock.Mock()
+        conn = mock.Mock(engine=bind)
+        bind.connect = mock.Mock(return_value=conn)
+        sess = Session(bind=bind)
+        sess.execute(text("select 1"))
+        with expect_warnings(
+            "Connection is already established for the "
+            "given bind; execution_options ignored"
+        ):
+            sess.connection(execution_options={"isolation_level": "FOO"})
+
+    def test_warning_on_using_inactive_session_new(self):
+        User = self.classes.User
+
+        sess, u1 = self._inactive_flushed_session_fixture()
+        u2 = User(name="u2")
+        sess.add(u2)
+
+        def go():
+            sess.rollback()
+
+        assert_warnings(
+            go,
+            [
+                "Session's state has been changed on a "
+                "non-active transaction - this state "
+                "will be discarded."
+            ],
+        )
+        assert u2 not in sess
+        assert u1 in sess
+
+    def test_warning_on_using_inactive_session_dirty(self):
+        sess, u1 = self._inactive_flushed_session_fixture()
+        u1.name = "newname"
+
+        def go():
+            sess.rollback()
+
+        assert_warnings(
+            go,
+            [
+                "Session's state has been changed on a "
+                "non-active transaction - this state "
+                "will be discarded."
+            ],
+        )
+        assert u1 in sess
+        assert u1 not in sess.dirty
+
+    def test_warning_on_using_inactive_session_delete(self):
+        sess, u1 = self._inactive_flushed_session_fixture()
+        sess.delete(u1)
+
+        def go():
+            sess.rollback()
+
+        assert_warnings(
+            go,
+            [
+                "Session's state has been changed on a "
+                "non-active transaction - this state "
+                "will be discarded."
+            ],
+        )
+        assert u1 in sess
+        assert u1 not in sess.deleted
+
+    def test_warning_on_using_inactive_session_rollback_evt(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        sess = fixture_session()
+        u1 = User(id=1, name="u1")
+        sess.add(u1)
+        sess.commit()
+
+        u3 = User(name="u3")
+
+        @event.listens_for(sess, "after_rollback")
+        def evt(s):
+            sess.add(u3)
+
+        sess.add(User(id=1, name="u2"))
+
+        def go():
+            assert_raises(orm_exc.FlushError, sess.flush)
+
+        assert u3 not in sess
+
+    def test_preserve_flush_error(self):
+        User = self.classes.User
+
+        sess, u1 = self._inactive_flushed_session_fixture()
+
+        for i in range(5):
+            assert_raises_message(
+                sa_exc.PendingRollbackError,
+                "^This Session's transaction has been "
+                r"rolled back due to a previous exception "
+                "during flush. To "
+                "begin a new transaction with this "
+                "Session, first issue "
+                r"Session.rollback\(\). Original exception "
+                "was:",
+                sess.commit,
+            )
+        sess.rollback()
+        sess.add(User(id=5, name="some name"))
+        sess.commit()
+
+    def test_no_autocommit_with_explicit_commit(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        session = fixture_session(autocommit=False)
+        session.add(User(name="ed"))
+        session._legacy_transaction().commit()
+
+        is_not(session._legacy_transaction(), None)
+
+    def test_no_autocommit_with_explicit_commit_future(self):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        session = fixture_session(autocommit=False, future=True)
+        session.add(User(name="ed"))
+        session._legacy_transaction().commit()
+
+        # new in 1.4
+        is_(session._legacy_transaction(), None)
+
+
+class _LocalFixture(FixtureTest):
+    run_setup_mappers = "once"
+    run_inserts = None
+
+    @classmethod
+    def setup_mappers(cls):
+        User, Address = cls.classes.User, cls.classes.Address
+        users, addresses = cls.tables.users, cls.tables.addresses
+        mapper(
+            User,
+            users,
+            properties={
+                "addresses": relationship(
+                    Address,
+                    backref="user",
+                    cascade="all, delete-orphan",
+                    order_by=addresses.c.id,
+                )
+            },
+        )
+        mapper(Address, addresses)
+
+
+def subtransaction_recipe_one(self):
+    @contextlib.contextmanager
+    def transaction(session):
+
+        if session.in_transaction():
+            outermost = False
+        else:
+            outermost = True
+            session.begin()
+
+        try:
+            yield
+        except:
+            if session.in_transaction():
+                session.rollback()
+            raise
+        else:
+            if outermost and session.in_transaction():
+                session.commit()
+
+    return transaction
+
+
+def subtransaction_recipe_two(self):
+    # shorter recipe
+    @contextlib.contextmanager
+    def transaction(session):
+        if not session.in_transaction():
+            with session.begin():
+                yield
+        else:
+            yield
+
+    return transaction
+
+
+def subtransaction_recipe_three(self):
+    @contextlib.contextmanager
+    def transaction(session):
+        if not session.in_transaction():
+            session.begin()
+            try:
+                yield
+            except:
+                if session.in_transaction():
+                    session.rollback()
+            else:
+                session.commit()
+        else:
+            try:
+                yield
+            except:
+                if session.in_transaction():
+                    session.rollback()
+                raise
+
+    return transaction
+
+
+@testing.combinations(
+    (subtransaction_recipe_one, True),
+    (subtransaction_recipe_two, False),
+    (subtransaction_recipe_three, True),
+    argnames="target_recipe,recipe_rollsback_early",
+    id_="ns",
+)
+@testing.combinations((True,), (False,), argnames="future", id_="s")
+class SubtransactionRecipeTest(FixtureTest):
+    run_inserts = None
+    __backend__ = True
+
+    @testing.fixture
+    def subtransaction_recipe(self):
+        return self.target_recipe()
+
+    @testing.requires.savepoints
+    def test_recipe_heavy_nesting(self, subtransaction_recipe):
+        users = self.tables.users
+
+        with fixture_session(future=self.future) as session:
+            with subtransaction_recipe(session):
+                session.connection().execute(
+                    users.insert().values(name="user1")
+                )
+                with subtransaction_recipe(session):
+                    savepoint = session.begin_nested()
+                    session.connection().execute(
+                        users.insert().values(name="user2")
+                    )
+                    assert (
+                        session.connection()
+                        .exec_driver_sql("select count(1) from users")
+                        .scalar()
+                        == 2
+                    )
+                    savepoint.rollback()
+
+                with subtransaction_recipe(session):
+                    assert (
+                        session.connection()
+                        .exec_driver_sql("select count(1) from users")
+                        .scalar()
+                        == 1
+                    )
+                    session.connection().execute(
+                        users.insert().values(name="user3")
+                    )
+                assert (
+                    session.connection()
+                    .exec_driver_sql("select count(1) from users")
+                    .scalar()
+                    == 2
+                )
+
+    @engines.close_open_connections
+    def test_recipe_subtransaction_on_external_subtrans(
+        self, subtransaction_recipe
+    ):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        with testing.db.connect() as conn:
+            trans = conn.begin()
+            sess = Session(conn, future=self.future)
+
+            with subtransaction_recipe(sess):
+                u = User(name="ed")
+                sess.add(u)
+                sess.flush()
+                # commit does nothing
+            trans.rollback()  # rolls back
+            assert len(sess.query(User).all()) == 0
+            sess.close()
+
+    def test_recipe_commit_one(self, subtransaction_recipe):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        with fixture_session(future=self.future) as sess:
+            with subtransaction_recipe(sess):
+                u = User(name="u1")
+                sess.add(u)
+            sess.close()
+            assert len(sess.query(User).all()) == 1
+
+    def test_recipe_subtransaction_on_noautocommit(
+        self, subtransaction_recipe
+    ):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+        with fixture_session(future=self.future) as sess:
+            sess.begin()
+            with subtransaction_recipe(sess):
+                u = User(name="u1")
+                sess.add(u)
+                sess.flush()
+            sess.rollback()  # rolls back
+            assert len(sess.query(User).all()) == 0
+            sess.close()
+
+    @testing.requires.savepoints
+    def test_recipe_mixed_transaction_control(self, subtransaction_recipe):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        with fixture_session(future=self.future) as sess:
+
+            sess.begin()
+            sess.begin_nested()
+
+            with subtransaction_recipe(sess):
+
+                sess.add(User(name="u1"))
+
+            sess.commit()
+            sess.commit()
+
+            eq_(len(sess.query(User).all()), 1)
+            sess.close()
+
+            t1 = sess.begin()
+            t2 = sess.begin_nested()
+
+            sess.add(User(name="u2"))
+
+            t2.commit()
+            assert sess._legacy_transaction() is t1
+
+    def test_recipe_error_on_using_inactive_session_commands(
+        self, subtransaction_recipe
+    ):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+        with fixture_session(future=self.future) as sess:
+            sess.begin()
+
+            try:
+                with subtransaction_recipe(sess):
+                    sess.add(User(name="u1"))
+                    sess.flush()
+                    raise Exception("force rollback")
+            except:
+                pass
+
+            if self.recipe_rollsback_early:
+                # that was a real rollback, so no transaction
+                assert not sess.in_transaction()
+                is_(sess.get_transaction(), None)
+            else:
+                assert sess.in_transaction()
+
+            sess.close()
+            assert not sess.in_transaction()
+
+    def test_recipe_multi_nesting(self, subtransaction_recipe):
+        with fixture_session(future=self.future) as sess:
+            with subtransaction_recipe(sess):
+                assert sess.in_transaction()
+
+                try:
+                    with subtransaction_recipe(sess):
+                        assert sess._legacy_transaction()
+                        raise Exception("force rollback")
+                except:
+                    pass
+
+                if self.recipe_rollsback_early:
+                    assert not sess.in_transaction()
+                else:
+                    assert sess.in_transaction()
+
+            assert not sess.in_transaction()
+
+    def test_recipe_deactive_status_check(self, subtransaction_recipe):
+        with fixture_session(future=self.future) as sess:
+            sess.begin()
+
+            with subtransaction_recipe(sess):
+                sess.rollback()
+
+            assert not sess.in_transaction()
+            sess.commit()  # no error
+
+
+class FixtureDataTest(_LocalFixture):
+    run_inserts = "each"
+    __backend__ = True
+
+    def test_attrs_on_rollback(self):
+        User = self.classes.User
+        sess = fixture_session()
+        u1 = sess.query(User).get(7)
+        u1.name = "ed"
+        sess.rollback()
+        eq_(u1.name, "jack")
+
+    def test_commit_persistent(self):
+        User = self.classes.User
+        sess = fixture_session()
+        u1 = sess.query(User).get(7)
+        u1.name = "ed"
+        sess.flush()
+        sess.commit()
+        eq_(u1.name, "ed")
+
+    def test_concurrent_commit_persistent(self):
+        User = self.classes.User
+        s1 = fixture_session()
+        u1 = s1.query(User).get(7)
+        u1.name = "ed"
+        s1.commit()
+
+        s2 = fixture_session()
+        u2 = s2.query(User).get(7)
+        assert u2.name == "ed"
+        u2.name = "will"
+        s2.commit()
+
+        assert u1.name == "will"
+
+
+class CleanSavepointTest(FixtureTest):
+
+    """test the behavior for [ticket:2452] - rollback on begin_nested()
+    only expires objects tracked as being modified in that transaction.
+
+    """
+
+    run_inserts = None
+    __backend__ = True
+
+    def _run_test(self, update_fn, future=False):
+        User, users = self.classes.User, self.tables.users
+
+        mapper(User, users)
+
+        with fixture_session(future=future) as s:
+            u1 = User(name="u1")
+            u2 = User(name="u2")
+            s.add_all([u1, u2])
+            s.commit()
+            u1.name
+            u2.name
+            trans = s._transaction
+            assert trans is not None
+            s.begin_nested()
+            update_fn(s, u2)
+            eq_(u2.name, "u2modified")
+            s.rollback()
+
+            if future:
+                assert s._transaction is None
+                assert "name" not in u1.__dict__
+            else:
+                assert s._transaction is trans
+                eq_(u1.__dict__["name"], "u1")
+            assert "name" not in u2.__dict__
+            eq_(u2.name, "u2")
+
+    @testing.requires.savepoints
+    def test_rollback_ignores_clean_on_savepoint(self):
+        def update_fn(s, u2):
+            u2.name = "u2modified"
+
+        self._run_test(update_fn)
+
+    @testing.requires.savepoints
+    def test_rollback_ignores_clean_on_savepoint_agg_upd_eval(self):
+        User = self.classes.User
+
+        def update_fn(s, u2):
+            s.query(User).filter_by(name="u2").update(
+                dict(name="u2modified"), synchronize_session="evaluate"
+            )
+
+        self._run_test(update_fn)
+
+    @testing.requires.savepoints
+    def test_rollback_ignores_clean_on_savepoint_agg_upd_fetch(self):
+        User = self.classes.User
+
+        def update_fn(s, u2):
+            s.query(User).filter_by(name="u2").update(
+                dict(name="u2modified"), synchronize_session="fetch"
+            )
+
+        self._run_test(update_fn)
+
+
+class AutoExpireTest(_LocalFixture):
+    __backend__ = True
+
+    def test_expunge_pending_on_rollback(self):
+        User = self.classes.User
+        sess = fixture_session()
+        u2 = User(name="newuser")
+        sess.add(u2)
+        assert u2 in sess
+        sess.rollback()
+        assert u2 not in sess
+
+    def test_trans_pending_cleared_on_commit(self):
+        User = self.classes.User
+        sess = fixture_session()
+        u2 = User(name="newuser")
+        sess.add(u2)
+        assert u2 in sess
+        sess.commit()
+        assert u2 in sess
+        u3 = User(name="anotheruser")
+        sess.add(u3)
+        sess.rollback()
+        assert u3 not in sess
+        assert u2 in sess
+
+    def test_update_deleted_on_rollback(self):
+        User = self.classes.User
+        s = fixture_session()
+        u1 = User(name="ed")
+        s.add(u1)
+        s.commit()
+
+        # this actually tests that the delete() operation,
+        # when cascaded to the "addresses" collection, does not
+        # trigger a flush (via lazyload) before the cascade is complete.
+        s.delete(u1)
+        assert u1 in s.deleted
+        s.rollback()
+        assert u1 in s
+        assert u1 not in s.deleted
+
+    @testing.requires.predictable_gc
+    def test_gced_delete_on_rollback(self):
+        User, users = self.classes.User, self.tables.users
+
+        s = fixture_session()
+        u1 = User(name="ed")
+        s.add(u1)
+        s.commit()
+
+        s.delete(u1)
+        u1_state = attributes.instance_state(u1)
+        assert u1_state in s.identity_map.all_states()
+        assert u1_state in s._deleted
+        s.flush()
+        assert u1_state not in s.identity_map.all_states()
+        assert u1_state not in s._deleted
+        del u1
+        gc_collect()
+        assert u1_state.obj() is None
+
+        s.rollback()
+        # new in 1.1, not in identity map if the object was
+        # gc'ed and we restore snapshot; we've changed update_impl
+        # to just skip this object
+        assert u1_state not in s.identity_map.all_states()
+
+        # in any version, the state is replaced by the query
+        # because the identity map would switch it
+        u1 = s.query(User).filter_by(name="ed").one()
+        assert u1_state not in s.identity_map.all_states()
+
+        eq_(s.scalar(select(func.count("*")).select_from(users)), 1)
+        s.delete(u1)
+        s.flush()
+        eq_(s.scalar(select(func.count("*")).select_from(users)), 0)
+        s.commit()
+
+    def test_trans_deleted_cleared_on_rollback(self):
+        User = self.classes.User
+        s = fixture_session()
+        u1 = User(name="ed")
+        s.add(u1)
+        s.commit()
+
+        s.delete(u1)
+        s.commit()
+        assert u1 not in s
+        s.rollback()
+        assert u1 not in s
+
+    def test_update_deleted_on_rollback_cascade(self):
+        User, Address = self.classes.User, self.classes.Address
+
+        s = fixture_session()
+        u1 = User(name="ed", addresses=[Address(email_address="foo")])
+        s.add(u1)
+        s.commit()
+
+        s.delete(u1)
+        assert u1 in s.deleted
+        assert u1.addresses[0] in s.deleted
+        s.rollback()
+        assert u1 in s
+        assert u1 not in s.deleted
+        assert u1.addresses[0] not in s.deleted
+
+    def test_update_deleted_on_rollback_orphan(self):
+        User, Address = self.classes.User, self.classes.Address
+
+        s = fixture_session()
+        u1 = User(name="ed", addresses=[Address(email_address="foo")])
+        s.add(u1)
+        s.commit()
+
+        a1 = u1.addresses[0]
+        u1.addresses.remove(a1)
+
+        s.flush()
+        eq_(s.query(Address).filter(Address.email_address == "foo").all(), [])
+        s.rollback()
+        assert a1 not in s.deleted
+        assert u1.addresses == [a1]
+
+    def test_commit_pending(self):
+        User = self.classes.User
+        sess = fixture_session()
+        u1 = User(name="newuser")
+        sess.add(u1)
+        sess.flush()
+        sess.commit()
+        eq_(u1.name, "newuser")
+
+    def test_concurrent_commit_pending(self):
+        User = self.classes.User
+        s1 = fixture_session()
+        u1 = User(name="edward")
+        s1.add(u1)
+        s1.commit()
+
+        s2 = fixture_session()
+        u2 = s2.query(User).filter(User.name == "edward").one()
+        u2.name = "will"
+        s2.commit()
+
+        assert u1.name == "will"
+
+
+class RollbackRecoverTest(_LocalFixture):
+    __backend__ = True
+
+    def test_pk_violation(self):
+        User, Address = self.classes.User, self.classes.Address
+        s = fixture_session()
+
+        a1 = Address(email_address="foo")
+        u1 = User(id=1, name="ed", addresses=[a1])
+        s.add(u1)
+        s.commit()
+
+        a2 = Address(email_address="bar")
+        u2 = User(id=1, name="jack", addresses=[a2])
+
+        u1.name = "edward"
+        a1.email_address = "foober"
+        s.add(u2)
+
+        with expect_warnings("New instance"):
+            assert_raises(sa_exc.IntegrityError, s.commit)
+
+        assert_raises(sa_exc.InvalidRequestError, s.commit)
+        s.rollback()
+        assert u2 not in s
+        assert a2 not in s
+        assert u1 in s
+        assert a1 in s
+        assert u1.name == "ed"
+        assert a1.email_address == "foo"
+        u1.name = "edward"
+        a1.email_address = "foober"
+        s.commit()
+        eq_(
+            s.query(User).all(),
+            [
+                User(
+                    id=1,
+                    name="edward",
+                    addresses=[Address(email_address="foober")],
+                )
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_pk_violation_with_savepoint(self):
+        User, Address = self.classes.User, self.classes.Address
+        s = fixture_session()
+        a1 = Address(email_address="foo")
+        u1 = User(id=1, name="ed", addresses=[a1])
+        s.add(u1)
+        s.commit()
+
+        a2 = Address(email_address="bar")
+        u2 = User(id=1, name="jack", addresses=[a2])
+
+        u1.name = "edward"
+        a1.email_address = "foober"
+        s.begin_nested()
+        s.add(u2)
+
+        with expect_warnings("New instance"):
+            assert_raises(sa_exc.IntegrityError, s.commit)
+        assert_raises(sa_exc.InvalidRequestError, s.commit)
+        s.rollback()
+        assert u2 not in s
+        assert a2 not in s
+        assert u1 in s
+        assert a1 in s
+
+        s.commit()
+        eq_(
+            s.query(User).all(),
+            [
+                User(
+                    id=1,
+                    name="edward",
+                    addresses=[Address(email_address="foober")],
+                )
+            ],
+        )
+
+
+class SavepointTest(_LocalFixture):
+    __backend__ = True
+
+    @testing.requires.savepoints
+    def test_savepoint_rollback(self):
+        User = self.classes.User
+        s = fixture_session()
+        u1 = User(name="ed")
+        u2 = User(name="jack")
+        s.add_all([u1, u2])
+
+        s.begin_nested()
+        u3 = User(name="wendy")
+        u4 = User(name="foo")
+        u1.name = "edward"
+        u2.name = "jackward"
+        s.add_all([u3, u4])
+        eq_(
+            s.query(User.name).order_by(User.id).all(),
+            [("edward",), ("jackward",), ("wendy",), ("foo",)],
+        )
+        s.rollback()
+        assert u1.name == "ed"
+        assert u2.name == "jack"
+        eq_(s.query(User.name).order_by(User.id).all(), [("ed",), ("jack",)])
+        s.commit()
+        assert u1.name == "ed"
+        assert u2.name == "jack"
+        eq_(s.query(User.name).order_by(User.id).all(), [("ed",), ("jack",)])
+
+    @testing.requires.savepoints
+    def test_savepoint_delete(self):
+        User = self.classes.User
+        s = fixture_session()
+        u1 = User(name="ed")
+        s.add(u1)
+        s.commit()
+        eq_(s.query(User).filter_by(name="ed").count(), 1)
+        s.begin_nested()
+        s.delete(u1)
+        s.commit()
+        eq_(s.query(User).filter_by(name="ed").count(), 0)
+        s.commit()
+
+    @testing.requires.savepoints
+    def test_savepoint_commit(self):
+        User = self.classes.User
+        s = fixture_session()
+        u1 = User(name="ed")
+        u2 = User(name="jack")
+        s.add_all([u1, u2])
+
+        s.begin_nested()
+        u3 = User(name="wendy")
+        u4 = User(name="foo")
+        u1.name = "edward"
+        u2.name = "jackward"
+        s.add_all([u3, u4])
+        eq_(
+            s.query(User.name).order_by(User.id).all(),
+            [("edward",), ("jackward",), ("wendy",), ("foo",)],
+        )
+        s.commit()
+
+        def go():
+            assert u1.name == "edward"
+            assert u2.name == "jackward"
+            eq_(
+                s.query(User.name).order_by(User.id).all(),
+                [("edward",), ("jackward",), ("wendy",), ("foo",)],
+            )
+
+        self.assert_sql_count(testing.db, go, 1)
+
+        s.commit()
+        eq_(
+            s.query(User.name).order_by(User.id).all(),
+            [("edward",), ("jackward",), ("wendy",), ("foo",)],
+        )
+
+    @testing.requires.savepoints
+    def test_savepoint_rollback_collections(self):
+        User, Address = self.classes.User, self.classes.Address
+        s = fixture_session()
+        u1 = User(name="ed", addresses=[Address(email_address="foo")])
+        s.add(u1)
+        s.commit()
+
+        u1.name = "edward"
+        u1.addresses.append(Address(email_address="bar"))
+        s.begin_nested()
+        u2 = User(name="jack", addresses=[Address(email_address="bat")])
+        s.add(u2)
+        eq_(
+            s.query(User).order_by(User.id).all(),
+            [
+                User(
+                    name="edward",
+                    addresses=[
+                        Address(email_address="foo"),
+                        Address(email_address="bar"),
+                    ],
+                ),
+                User(name="jack", addresses=[Address(email_address="bat")]),
+            ],
+        )
+        s.rollback()
+        eq_(
+            s.query(User).order_by(User.id).all(),
+            [
+                User(
+                    name="edward",
+                    addresses=[
+                        Address(email_address="foo"),
+                        Address(email_address="bar"),
+                    ],
+                )
+            ],
+        )
+        s.commit()
+        eq_(
+            s.query(User).order_by(User.id).all(),
+            [
+                User(
+                    name="edward",
+                    addresses=[
+                        Address(email_address="foo"),
+                        Address(email_address="bar"),
+                    ],
+                )
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_savepoint_commit_collections(self):
+        User, Address = self.classes.User, self.classes.Address
+        s = fixture_session()
+        u1 = User(name="ed", addresses=[Address(email_address="foo")])
+        s.add(u1)
+        s.commit()
+
+        u1.name = "edward"
+        u1.addresses.append(Address(email_address="bar"))
+        s.begin_nested()
+        u2 = User(name="jack", addresses=[Address(email_address="bat")])
+        s.add(u2)
+        eq_(
+            s.query(User).order_by(User.id).all(),
+            [
+                User(
+                    name="edward",
+                    addresses=[
+                        Address(email_address="foo"),
+                        Address(email_address="bar"),
+                    ],
+                ),
+                User(name="jack", addresses=[Address(email_address="bat")]),
+            ],
+        )
+        s.commit()
+        eq_(
+            s.query(User).order_by(User.id).all(),
+            [
+                User(
+                    name="edward",
+                    addresses=[
+                        Address(email_address="foo"),
+                        Address(email_address="bar"),
+                    ],
+                ),
+                User(name="jack", addresses=[Address(email_address="bat")]),
+            ],
+        )
+        s.commit()
+        eq_(
+            s.query(User).order_by(User.id).all(),
+            [
+                User(
+                    name="edward",
+                    addresses=[
+                        Address(email_address="foo"),
+                        Address(email_address="bar"),
+                    ],
+                ),
+                User(name="jack", addresses=[Address(email_address="bat")]),
+            ],
+        )
+
+    @testing.requires.savepoints
+    def test_expunge_pending_on_rollback(self):
+        User = self.classes.User
+        sess = fixture_session()
+
+        sess.begin_nested()
+        u2 = User(name="newuser")
+        sess.add(u2)
+        assert u2 in sess
+        sess.rollback()
+        assert u2 not in sess
+
+    @testing.requires.savepoints
+    def test_update_deleted_on_rollback(self):
+        User = self.classes.User
+        s = fixture_session()
+        u1 = User(name="ed")
+        s.add(u1)
+        s.commit()
+
+        s.begin_nested()
+        s.delete(u1)
+        assert u1 in s.deleted
+        s.rollback()
+        assert u1 in s
+        assert u1 not in s.deleted
+
+    @testing.requires.savepoints_w_release
+    def test_savepoint_lost_still_runs(self):
+        User = self.classes.User
+        s = fixture_session()
+        trans = s.begin_nested()
+        s.connection()
+        u1 = User(name="ed")
+        s.add(u1)
+
+        # kill off the transaction
+        nested_trans = trans._connections[self.bind][1]
+        nested_trans._do_commit()
+
+        is_(s._legacy_transaction(), trans)
+
+        with expect_warnings("nested transaction already deassociated"):
+            # this previously would raise
+            # "savepoint "sa_savepoint_1" does not exist", however as of
+            # #5327 the savepoint already knows it's inactive
+            s.rollback()
+
+        assert u1 not in s.new
+
+        is_(trans._state, _session.CLOSED)
+        is_not(s._legacy_transaction(), trans)
+        is_(s._legacy_transaction()._state, _session.ACTIVE)
+
+        is_(s._legacy_transaction().nested, False)
+
+        is_(s._legacy_transaction()._parent, None)
+
+
+class AccountingFlagsTest(_LocalFixture):
+    __backend__ = True
+
+    def test_no_expire_on_commit(self):
+        User, users = self.classes.User, self.tables.users
+
+        sess = fixture_session(expire_on_commit=False)
+        u1 = User(name="ed")
+        sess.add(u1)
+        sess.commit()
+
+        sess.execute(users.update(users.c.name == "ed").values(name="edward"))
+
+        assert u1.name == "ed"
+        sess.expire_all()
+        assert u1.name == "edward"
+
+
+class AutoCommitTest(_LocalFixture):
+    __backend__ = True
+
+    def test_begin_nested_requires_trans(self):
+        sess = fixture_session(autocommit=True)
+        assert_raises(sa_exc.InvalidRequestError, sess.begin_nested)
+
+    def test_begin_preflush(self):
+        User = self.classes.User
+        sess = fixture_session(autocommit=True)
+
+        u1 = User(name="ed")
+        sess.add(u1)
+
+        sess.begin()
+        u2 = User(name="some other user")
+        sess.add(u2)
+        sess.rollback()
+        assert u2 not in sess
+        assert u1 in sess
+        assert sess.query(User).filter_by(name="ed").one() is u1
+
+    def test_accounting_commit_fails_add(self):
+        User = self.classes.User
+        sess = fixture_session(autocommit=True)
+
+        fail = False
+
+        def fail_fn(*arg, **kw):
+            if fail:
+                raise Exception("commit fails")
+
+        event.listen(sess, "after_flush_postexec", fail_fn)
+        u1 = User(name="ed")
+        sess.add(u1)
+
+        fail = True
+        assert_raises(Exception, sess.flush)
+        fail = False
+
+        assert u1 not in sess
+        u1new = User(id=2, name="fred")
+        sess.add(u1new)
+        sess.add(u1)
+        sess.flush()
+        assert u1 in sess
+        eq_(
+            sess.query(User.name).order_by(User.name).all(),
+            [("ed",), ("fred",)],
+        )
+
+    def test_accounting_commit_fails_delete(self):
+        User = self.classes.User
+        sess = fixture_session(autocommit=True)
+
+        fail = False
+
+        def fail_fn(*arg, **kw):
+            if fail:
+                raise Exception("commit fails")
+
+        event.listen(sess, "after_flush_postexec", fail_fn)
+        u1 = User(name="ed")
+        sess.add(u1)
+        sess.flush()
+
+        sess.delete(u1)
+        fail = True
+        assert_raises(Exception, sess.flush)
+        fail = False
+
+        assert u1 in sess
+        assert u1 not in sess.deleted
+        sess.delete(u1)
+        sess.flush()
+        assert u1 not in sess
+        eq_(sess.query(User.name).order_by(User.name).all(), [])
+
+    @testing.requires.updateable_autoincrement_pks
+    def test_accounting_no_select_needed(self):
+        """test that flush accounting works on non-expired instances
+        when autocommit=True/expire_on_commit=True."""
+
+        User = self.classes.User
+        sess = fixture_session(autocommit=True, expire_on_commit=True)
+
+        u1 = User(id=1, name="ed")
+        sess.add(u1)
+        sess.flush()
+
+        u1.id = 3
+        u1.name = "fred"
+        self.assert_sql_count(testing.db, sess.flush, 1)
+        assert "id" not in u1.__dict__
+        eq_(u1.id, 3)
+
+
+class ContextManagerPlusFutureTest(FixtureTest):
+    run_inserts = None
+    __backend__ = True
+
+    @testing.requires.savepoints
+    @engines.close_open_connections
+    def test_contextmanager_nested_rollback(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        sess = fixture_session()
+
+        def go():
+            with sess.begin_nested():
+                sess.add(User())  # name can't be null
+                sess.flush()
+
+        # and not InvalidRequestError
+        assert_raises(sa_exc.DBAPIError, go)
+
+        with sess.begin_nested():
+            sess.add(User(name="u1"))
+
+        eq_(sess.query(User).count(), 1)
+
+    def test_contextmanager_commit(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        sess = fixture_session()
+        with sess.begin():
+            sess.add(User(name="u1"))
+
+        sess.rollback()
+        eq_(sess.query(User).count(), 1)
+
+    def test_contextmanager_rollback(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        sess = fixture_session()
+
+        def go():
+            with sess.begin():
+                sess.add(User())  # name can't be null
+
+        assert_raises(sa_exc.DBAPIError, go)
+
+        eq_(sess.query(User).count(), 0)
+        sess.close()
+
+        with sess.begin():
+            sess.add(User(name="u1"))
+        eq_(sess.query(User).count(), 1)
+
+    def test_explicit_begin(self):
+        with fixture_session() as s1:
+            with s1.begin() as trans:
+                is_(trans, s1._legacy_transaction())
+                s1.connection()
+
+            is_(s1._transaction, None)
+
+    def test_no_double_begin_explicit(self):
+        with fixture_session() as s1:
+            s1.begin()
+            assert_raises_message(
+                sa_exc.InvalidRequestError,
+                "A transaction is already begun on this Session.",
+                s1.begin,
+            )
+
+    @testing.requires.savepoints
+    def test_future_rollback_is_global(self):
+        users = self.tables.users
+
+        with fixture_session(future=True) as s1:
+            s1.begin()
+
+            s1.connection().execute(users.insert(), [{"id": 1, "name": "n1"}])
+
+            s1.begin_nested()
+
+            s1.connection().execute(
+                users.insert(),
+                [{"id": 2, "name": "n2"}, {"id": 3, "name": "n3"}],
+            )
+
+            eq_(
+                s1.connection().scalar(
+                    select(func.count()).select_from(users)
+                ),
+                3,
+            )
+
+            # rolls back the whole transaction
+            s1.rollback()
+            is_(s1._legacy_transaction(), None)
+
+            eq_(
+                s1.connection().scalar(
+                    select(func.count()).select_from(users)
+                ),
+                0,
+            )
+
+            s1.commit()
+            is_(s1._legacy_transaction(), None)
+
+    @testing.requires.savepoints
+    def test_old_rollback_is_local(self):
+        users = self.tables.users
+
+        with fixture_session() as s1:
+
+            t1 = s1.begin()
+
+            s1.connection().execute(users.insert(), [{"id": 1, "name": "n1"}])
+
+            s1.begin_nested()
+
+            s1.connection().execute(
+                users.insert(),
+                [{"id": 2, "name": "n2"}, {"id": 3, "name": "n3"}],
+            )
+
+            eq_(
+                s1.connection().scalar(
+                    select(func.count()).select_from(users)
+                ),
+                3,
+            )
+
+            # rolls back only the savepoint
+            s1.rollback()
+
+            is_(s1._legacy_transaction(), t1)
+
+            eq_(
+                s1.connection().scalar(
+                    select(func.count()).select_from(users)
+                ),
+                1,
+            )
+
+            s1.commit()
+            eq_(
+                s1.connection().scalar(
+                    select(func.count()).select_from(users)
+                ),
+                1,
+            )
+            is_not(s1._legacy_transaction(), None)
+
+    def test_session_as_ctx_manager_one(self):
+        users = self.tables.users
+
+        with fixture_session() as sess:
+            is_not(sess._legacy_transaction(), None)
+
+            sess.connection().execute(
+                users.insert().values(id=1, name="user1")
+            )
+
+            eq_(
+                sess.connection().execute(users.select()).all(), [(1, "user1")]
+            )
+
+            is_not(sess._legacy_transaction(), None)
+
+        is_not(sess._legacy_transaction(), None)
+
+        # did not commit
+        eq_(sess.connection().execute(users.select()).all(), [])
+
+    def test_session_as_ctx_manager_future_one(self):
+        users = self.tables.users
+
+        with fixture_session(future=True) as sess:
+            is_(sess._legacy_transaction(), None)
+
+            sess.connection().execute(
+                users.insert().values(id=1, name="user1")
+            )
+
+            eq_(
+                sess.connection().execute(users.select()).all(), [(1, "user1")]
+            )
+
+            is_not(sess._legacy_transaction(), None)
+
+        is_(sess._legacy_transaction(), None)
+
+        # did not commit
+        eq_(sess.connection().execute(users.select()).all(), [])
+
+    def test_session_as_ctx_manager_two(self):
+        users = self.tables.users
+
+        try:
+            with fixture_session() as sess:
+                is_not(sess._legacy_transaction(), None)
+
+                sess.connection().execute(
+                    users.insert().values(id=1, name="user1")
+                )
+
+                raise Exception("force rollback")
+        except:
+            pass
+        is_not(sess._legacy_transaction(), None)
+
+    def test_session_as_ctx_manager_two_future(self):
+        users = self.tables.users
+
+        try:
+            with fixture_session(future=True) as sess:
+                is_(sess._legacy_transaction(), None)
+
+                sess.connection().execute(
+                    users.insert().values(id=1, name="user1")
+                )
+
+                raise Exception("force rollback")
+        except:
+            pass
+        is_(sess._legacy_transaction(), None)
+
+    def test_begin_context_manager(self):
+        users = self.tables.users
+
+        with fixture_session() as sess:
+            with sess.begin():
+                sess.connection().execute(
+                    users.insert().values(id=1, name="user1")
+                )
+
+                eq_(
+                    sess.connection().execute(users.select()).all(),
+                    [(1, "user1")],
+                )
+
+        # committed
+        eq_(sess.connection().execute(users.select()).all(), [(1, "user1")])
+
+    def test_sessionmaker_begin_context_manager(self):
+        users = self.tables.users
+
+        session = sessionmaker(testing.db)
+
+        with session.begin() as sess:
+            sess.connection().execute(
+                users.insert().values(id=1, name="user1")
+            )
+
+            eq_(
+                sess.connection().execute(users.select()).all(),
+                [(1, "user1")],
+            )
+
+        # committed
+        eq_(sess.connection().execute(users.select()).all(), [(1, "user1")])
+        sess.close()
+
+    def test_begin_context_manager_rollback_trans(self):
+        users = self.tables.users
+
+        try:
+            with fixture_session() as sess:
+                with sess.begin():
+                    sess.connection().execute(
+                        users.insert().values(id=1, name="user1")
+                    )
+
+                    eq_(
+                        sess.connection().execute(users.select()).all(),
+                        [(1, "user1")],
+                    )
+
+                    raise Exception("force rollback")
+        except:
+            pass
+
+        # rolled back
+        eq_(sess.connection().execute(users.select()).all(), [])
+        sess.close()
+
+    def test_begin_context_manager_rollback_outer(self):
+        users = self.tables.users
+
+        try:
+            with fixture_session() as sess:
+                with sess.begin():
+                    sess.connection().execute(
+                        users.insert().values(id=1, name="user1")
+                    )
+
+                    eq_(
+                        sess.connection().execute(users.select()).all(),
+                        [(1, "user1")],
+                    )
+
+                raise Exception("force rollback")
+        except:
+            pass
+
+        # committed
+        eq_(sess.connection().execute(users.select()).all(), [(1, "user1")])
+        sess.close()
+
+    def test_sessionmaker_begin_context_manager_rollback_trans(self):
+        users = self.tables.users
+
+        session = sessionmaker(testing.db)
+
+        try:
+            with session.begin() as sess:
+                sess.connection().execute(
+                    users.insert().values(id=1, name="user1")
+                )
+
+                eq_(
+                    sess.connection().execute(users.select()).all(),
+                    [(1, "user1")],
+                )
+
+                raise Exception("force rollback")
+        except:
+            pass
+
+        # rolled back
+        eq_(sess.connection().execute(users.select()).all(), [])
+        sess.close()
+
+    def test_sessionmaker_begin_context_manager_rollback_outer(self):
+        users = self.tables.users
+
+        session = sessionmaker(testing.db)
+
+        try:
+            with session.begin() as sess:
+                sess.connection().execute(
+                    users.insert().values(id=1, name="user1")
+                )
+
+                eq_(
+                    sess.connection().execute(users.select()).all(),
+                    [(1, "user1")],
+                )
+
+            raise Exception("force rollback")
+        except:
+            pass
+
+        # committed
+        eq_(sess.connection().execute(users.select()).all(), [(1, "user1")])
+        sess.close()
+
+    @testing.combinations((True,), (False,), argnames="future")
+    def test_interrupt_ctxmanager(self, trans_ctx_manager_fixture, future):
+        fn = trans_ctx_manager_fixture
+
+        session = fixture_session(future=future)
+
+        fn(session, trans_on_subject=True, execute_on_subject=True)
+
+    @testing.combinations((True,), (False,), argnames="future")
+    @testing.combinations((True,), (False,), argnames="rollback")
+    @testing.combinations((True,), (False,), argnames="expire_on_commit")
+    @testing.combinations(
+        ("add",),
+        ("modify",),
+        ("delete",),
+        ("begin",),
+        argnames="check_operation",
+    )
+    def test_interrupt_ctxmanager_ops(
+        self, future, rollback, expire_on_commit, check_operation
+    ):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        session = fixture_session(
+            future=future, expire_on_commit=expire_on_commit
+        )
+
+        with session.begin():
+            u1 = User(id=7, name="u1")
+            session.add(u1)
+
+        with session.begin():
+            u1.name  # unexpire
+            u2 = User(id=8, name="u1")
+            session.add(u2)
+
+            session.flush()
+
+            if rollback:
+                session.rollback()
+            else:
+                session.commit()
+
+            with expect_raises_message(
+                sa_exc.InvalidRequestError,
+                "Can't operate on closed transaction "
+                "inside context manager.  Please complete the context "
+                "manager before emitting further commands.",
+            ):
+                if check_operation == "add":
+                    u3 = User(id=9, name="u2")
+                    session.add(u3)
+                elif check_operation == "begin":
+                    session.begin()
+                elif check_operation == "modify":
+                    u1.name = "newname"
+                elif check_operation == "delete":
+                    session.delete(u1)
+
+
+class TransactionFlagsTest(fixtures.TestBase):
+    def test_in_transaction(self):
+        with fixture_session() as s1:
+
+            eq_(s1.in_transaction(), False)
+
+            trans = s1.begin()
+
+            eq_(s1.in_transaction(), True)
+            is_(s1.get_transaction(), trans)
+
+            n1 = s1.begin_nested()
+
+            eq_(s1.in_transaction(), True)
+            is_(s1.get_transaction(), trans)
+            is_(s1.get_nested_transaction(), n1)
+
+            n1.rollback()
+
+            is_(s1.get_nested_transaction(), None)
+            is_(s1.get_transaction(), trans)
+
+            eq_(s1.in_transaction(), True)
+
+            s1.commit()
+
+            eq_(s1.in_transaction(), False)
+            is_(s1.get_transaction(), None)
+
+    def test_in_transaction_subtransactions(self):
+        """we'd like to do away with subtransactions for future sessions
+        entirely.  at the moment we are still using them internally.
+        it might be difficult to keep the internals working in exactly
+        the same way if remove this concept, so for now just test that
+        the external API works.
+
+        """
+        with fixture_session() as s1:
+            eq_(s1.in_transaction(), False)
+
+            trans = s1.begin()
+
+            eq_(s1.in_transaction(), True)
+            is_(s1.get_transaction(), trans)
+
+            subtrans = s1.begin(_subtrans=True)
+            is_(s1.get_transaction(), trans)
+            eq_(s1.in_transaction(), True)
+
+            is_(s1._transaction, subtrans)
+
+            s1.rollback()
+
+            eq_(s1.in_transaction(), True)
+            is_(s1._transaction, trans)
+
+            s1.rollback()
+
+            eq_(s1.in_transaction(), False)
+            is_(s1._transaction, None)
+
+    def test_in_transaction_nesting(self):
+        with fixture_session() as s1:
+
+            eq_(s1.in_transaction(), False)
+
+            trans = s1.begin()
+
+            eq_(s1.in_transaction(), True)
+            is_(s1.get_transaction(), trans)
+
+            sp1 = s1.begin_nested()
+
+            eq_(s1.in_transaction(), True)
+            is_(s1.get_transaction(), trans)
+            is_(s1.get_nested_transaction(), sp1)
+
+            sp2 = s1.begin_nested()
+
+            eq_(s1.in_transaction(), True)
+            eq_(s1.in_nested_transaction(), True)
+            is_(s1.get_transaction(), trans)
+            is_(s1.get_nested_transaction(), sp2)
+
+            sp2.rollback()
+
+            eq_(s1.in_transaction(), True)
+            eq_(s1.in_nested_transaction(), True)
+            is_(s1.get_transaction(), trans)
+            is_(s1.get_nested_transaction(), sp1)
+
+            sp1.rollback()
+
+            is_(s1.get_nested_transaction(), None)
+            eq_(s1.in_transaction(), True)
+            eq_(s1.in_nested_transaction(), False)
+            is_(s1.get_transaction(), trans)
+
+            s1.rollback()
+
+            eq_(s1.in_transaction(), False)
+            is_(s1.get_transaction(), None)
+
+
+class NaturalPKRollbackTest(fixtures.MappedTest):
+    __backend__ = True
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table("users", metadata, Column("name", String(50), primary_key=True))
+
+    @classmethod
+    def setup_classes(cls):
+        class User(cls.Comparable):
+            pass
+
+    def test_rollback_recover(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        session = fixture_session()
+
+        u1, u2, u3 = User(name="u1"), User(name="u2"), User(name="u3")
+
+        session.add_all([u1, u2, u3])
+
+        session.commit()
+
+        session.delete(u2)
+        u4 = User(name="u2")
+        session.add(u4)
+        session.flush()
+
+        u5 = User(name="u3")
+        session.add(u5)
+        with expect_warnings("New instance"):
+            assert_raises(sa_exc.IntegrityError, session.flush)
+
+        assert u5 not in session
+        assert u2 not in session.deleted
+
+        session.rollback()
+
+    def test_reloaded_deleted_checked_for_expiry(self):
+        """test issue #3677"""
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        u1 = User(name="u1")
+
+        s = fixture_session()
+        s.add(u1)
+        s.flush()
+        del u1
+        gc_collect()
+
+        u1 = s.query(User).first()  # noqa
+
+        s.rollback()
+
+        u2 = User(name="u1")
+        s.add(u2)
+        s.commit()
+
+        assert inspect(u2).persistent
+
+    def test_key_replaced_by_update(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        u1 = User(name="u1")
+        u2 = User(name="u2")
+
+        s = fixture_session()
+        s.add_all([u1, u2])
+        s.commit()
+
+        s.delete(u1)
+        s.flush()
+
+        u2.name = "u1"
+        s.flush()
+
+        assert u1 not in s
+        s.rollback()
+
+        assert u1 in s
+        assert u2 in s
+
+        assert s.identity_map[identity_key(User, ("u1",))] is u1
+        assert s.identity_map[identity_key(User, ("u2",))] is u2
+
+    @testing.requires.savepoints
+    def test_key_replaced_by_update_nested(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        u1 = User(name="u1")
+
+        s = fixture_session()
+        s.add(u1)
+        s.commit()
+
+        with s.begin_nested():
+            u2 = User(name="u2")
+            s.add(u2)
+            s.flush()
+
+            u2.name = "u3"
+
+        s.rollback()
+
+        assert u1 in s
+        assert u2 not in s
+
+        u1.name = "u5"
+
+        s.commit()
+
+    def test_multiple_key_replaced_by_update(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        u1 = User(name="u1")
+        u2 = User(name="u2")
+        u3 = User(name="u3")
+
+        s = fixture_session()
+        s.add_all([u1, u2, u3])
+        s.commit()
+
+        s.delete(u1)
+        s.delete(u2)
+        s.flush()
+
+        u3.name = "u1"
+        s.flush()
+
+        u3.name = "u2"
+        s.flush()
+
+        s.rollback()
+
+        assert u1 in s
+        assert u2 in s
+        assert u3 in s
+
+        assert s.identity_map[identity_key(User, ("u1",))] is u1
+        assert s.identity_map[identity_key(User, ("u2",))] is u2
+        assert s.identity_map[identity_key(User, ("u3",))] is u3
+
+    def test_key_replaced_by_oob_insert(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        u1 = User(name="u1")
+
+        s = fixture_session()
+        s.add(u1)
+        s.commit()
+
+        s.delete(u1)
+        s.flush()
+
+        s.execute(users.insert().values(name="u1"))
+        u2 = s.query(User).get("u1")
+
+        assert u1 not in s
+        s.rollback()
+
+        assert u1 in s
+        assert u2 not in s
+
+        assert s.identity_map[identity_key(User, ("u1",))] is u1
+
+
+class JoinIntoAnExternalTransactionFixture(object):
+    """Test the "join into an external transaction" examples"""
+
+    __leave_connections_for_teardown__ = True
+
+    def setup_test(self):
+        self.engine = testing.db
+        self.connection = self.engine.connect()
+
+        self.metadata = MetaData()
+        self.table = Table(
+            "t1", self.metadata, Column("id", Integer, primary_key=True)
+        )
+        with self.connection.begin():
+            self.table.create(self.connection, checkfirst=True)
+
+        self.setup_session()
+
+    def teardown_test(self):
+        self.teardown_session()
+
+        with self.connection.begin():
+            self._assert_count(0)
+
+        with self.connection.begin():
+            self.table.drop(self.connection)
+
+        self.connection.close()
+
+    def test_something(self):
+        A = self.A
+
+        a1 = A()
+        self.session.add(a1)
+        self.session.commit()
+
+        self._assert_count(1)
+
+    def _assert_count(self, count):
+        result = self.connection.scalar(
+            select(func.count()).select_from(self.table)
+        )
+        eq_(result, count)
+
+
+class NewStyleJoinIntoAnExternalTransactionTest(
+    JoinIntoAnExternalTransactionFixture
+):
+    """A new recipe for "join into an external transaction" that works
+    for both legacy and future engines/sessions
+
+    """
+
+    def setup_session(self):
+        # begin a non-ORM transaction
+        self.trans = self.connection.begin()
+
+        class A(object):
+            pass
+
+        mapper(A, self.table)
+        self.A = A
+
+        # bind an individual Session to the connection
+        self.session = Session(bind=self.connection, future=True)
+
+        if testing.requires.savepoints.enabled:
+            self.nested = self.connection.begin_nested()
+
+            @event.listens_for(self.session, "after_transaction_end")
+            def end_savepoint(session, transaction):
+                if not self.nested.is_active:
+                    self.nested = self.connection.begin_nested()
+
+    def teardown_session(self):
+        self.session.close()
+
+        # rollback - everything that happened with the
+        # Session above (including calls to commit())
+        # is rolled back.
+        if self.trans.is_active:
+            self.trans.rollback()
+
+    @testing.requires.savepoints
+    def test_something_with_context_managers(self):
+        A = self.A
+
+        a1 = A()
+
+        with self.session.begin():
+            self.session.add(a1)
+            self.session.flush()
+
+            self._assert_count(1)
+            self.session.rollback()
+
+        self._assert_count(0)
+
+        a1 = A()
+        with self.session.begin():
+            self.session.add(a1)
+
+        self._assert_count(1)
+
+        a2 = A()
+
+        with self.session.begin():
+            self.session.add(a2)
+            self.session.flush()
+            self._assert_count(2)
+
+            self.session.rollback()
+        self._assert_count(1)
+
+
+class FutureJoinIntoAnExternalTransactionTest(
+    NewStyleJoinIntoAnExternalTransactionTest,
+    fixtures.FutureEngineMixin,
+    fixtures.TestBase,
+):
+    pass
+
+
+class NonFutureJoinIntoAnExternalTransactionTest(
+    NewStyleJoinIntoAnExternalTransactionTest,
+    fixtures.TestBase,
+):
+    pass
+
+
+class LegacyJoinIntoAnExternalTransactionTest(
+    JoinIntoAnExternalTransactionFixture,
+    fixtures.TestBase,
+):
+    def setup_session(self):
+        # begin a non-ORM transaction
+        self.trans = self.connection.begin()
+
+        class A(object):
+            pass
+
+        mapper(A, self.table)
+        self.A = A
+
+        # bind an individual Session to the connection
+        self.session = Session(bind=self.connection)
+
+        if testing.requires.savepoints.enabled:
+            # start the session in a SAVEPOINT...
+            self.session.begin_nested()
+
+            # then each time that SAVEPOINT ends, reopen it
+            @event.listens_for(self.session, "after_transaction_end")
+            def restart_savepoint(session, transaction):
+                if transaction.nested and not transaction._parent.nested:
+
+                    # ensure that state is expired the way
+                    # session.commit() at the top level normally does
+                    # (optional step)
+                    session.expire_all()
+
+                    session.begin_nested()
+
+    def teardown_session(self):
+        self.session.close()
+
+        # rollback - everything that happened with the
+        # Session above (including calls to commit())
+        # is rolled back.
+        self.trans.rollback()
+
+
+class LegacyBranchedJoinIntoAnExternalTransactionTest(
+    LegacyJoinIntoAnExternalTransactionTest
+):
+    def setup_session(self):
+        # begin a non-ORM transaction
+        self.trans = self.connection.begin()
+
+        class A(object):
+            pass
+
+        mapper(A, self.table)
+        self.A = A
+
+        # neutron is doing this inside of a migration
+        # 1df244e556f5_add_unique_ha_router_agent_port_bindings.py
+        with testing.expect_deprecated_20(
+            r"The Connection.connect\(\) method is considered legacy"
+        ):
+            self.session = Session(bind=self.connection.connect())
+
+        if testing.requires.savepoints.enabled:
+            # start the session in a SAVEPOINT...
+            self.session.begin_nested()
+
+            # then each time that SAVEPOINT ends, reopen it
+            @event.listens_for(self.session, "after_transaction_end")
+            def restart_savepoint(session, transaction):
+                if transaction.nested and not transaction._parent.nested:
+
+                    # ensure that state is expired the way
+                    # session.commit() at the top level normally does
+                    # (optional step)
+                    session.expire_all()
+
+                    session.begin_nested()

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -15,11 +15,57 @@ from sqlalchemy.testing.suite import *  # noqa
 
 from sqlalchemy.testing.suite import QuotedNameArgumentTest \
     as _QuotedNameArgumentTest
+from sqlalchemy.testing.suite import ComponentReflectionTest \
+    as _ComponentReflectionTest
 from sqlalchemy.testing.suite import config
 
 
 class QuotedNameArgumentTest(_QuotedNameArgumentTest):
     @_QuotedNameArgumentTest.quote_fixtures
     def test_get_foreign_keys(self, name):
-        if config.db.dialect.tidb_version >= (5,):
+        if config.db.dialect.tidb_version >= (6, 6, 0):
             super().test_get_foreign_keys(name, None)
+
+
+class ComponentReflectionTest(_ComponentReflectionTest):
+    @testing.combinations(
+        (False,), (True, testing.requires.schemas), argnames="use_schema"
+    )
+    @testing.requires.foreign_key_constraint_reflection
+    def test_get_foreign_keys(self, connection, use_schema):
+        if use_schema:
+            schema = config.test_schema
+        else:
+            schema = None
+
+        users, addresses = (self.tables.users, self.tables.email_addresses)
+        insp = inspect(connection)
+        expected_schema = schema
+        # users
+
+        if testing.requires.self_referential_foreign_keys.enabled:
+            users_fkeys = insp.get_foreign_keys(users.name, schema=schema)
+            fkey1 = users_fkeys[0]
+
+            with testing.requires.named_constraints.fail_if():
+                eq_(fkey1["name"], "user_id_fk")
+
+            # TiDB always returns `referred_schema`
+            # eq_(fkey1["referred_schema"], expected_schema)
+            eq_(fkey1["referred_table"], users.name)
+            eq_(fkey1["referred_columns"], ["user_id"])
+            if testing.requires.self_referential_foreign_keys.enabled:
+                eq_(fkey1["constrained_columns"], ["parent_user_id"])
+
+        # addresses
+        addr_fkeys = insp.get_foreign_keys(addresses.name, schema=schema)
+        fkey1 = addr_fkeys[0]
+
+        with testing.requires.implicitly_named_constraints.fail_if():
+            self.assert_(fkey1["name"] is not None)
+
+        # TiDB always returns `referred_schema`
+        # eq_(fkey1["referred_schema"], expected_schema)
+        eq_(fkey1["referred_table"], users.name)
+        eq_(fkey1["referred_columns"], ["user_id"])
+        eq_(fkey1["constrained_columns"], ["remote_user_id"])

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sqlalchemy import testing, inspect
+from sqlalchemy.testing import eq_
 from sqlalchemy.testing.suite import *  # noqa
 
 from sqlalchemy.testing.suite import QuotedNameArgumentTest \
@@ -40,7 +42,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
         users, addresses = (self.tables.users, self.tables.email_addresses)
         insp = inspect(connection)
-        expected_schema = schema
+        # expected_schema = schema
         # users
 
         if testing.requires.self_referential_foreign_keys.enabled:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -50,7 +50,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
             with testing.requires.named_constraints.fail_if():
                 eq_(fkey1["name"], "user_id_fk")
 
-            # TiDB always returns `referred_schema`
             eq_(fkey1["referred_table"], users.name)
             eq_(fkey1["referred_columns"], ["user_id"])
             if testing.requires.self_referential_foreign_keys.enabled:
@@ -63,8 +62,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         with testing.requires.implicitly_named_constraints.fail_if():
             self.assert_(fkey1["name"] is not None)
 
-        # TiDB always returns `referred_schema`
-        # eq_(fkey1["referred_schema"], expected_schema)
         eq_(fkey1["referred_table"], users.name)
         eq_(fkey1["referred_columns"], ["user_id"])
         eq_(fkey1["constrained_columns"], ["remote_user_id"])

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -42,8 +42,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
         users, addresses = (self.tables.users, self.tables.email_addresses)
         insp = inspect(connection)
-        # expected_schema = schema
-        # users
 
         if testing.requires.self_referential_foreign_keys.enabled:
             users_fkeys = insp.get_foreign_keys(users.name, schema=schema)
@@ -53,7 +51,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                 eq_(fkey1["name"], "user_id_fk")
 
             # TiDB always returns `referred_schema`
-            # eq_(fkey1["referred_schema"], expected_schema)
             eq_(fkey1["referred_table"], users.name)
             eq_(fkey1["referred_columns"], ["user_id"])
             if testing.requires.self_referential_foreign_keys.enabled:

--- a/test/test_type.py
+++ b/test/test_type.py
@@ -733,7 +733,7 @@ class TypeRoundTripTest(fixtures.TestBase, AssertsExecutionResults):
 
 class JSONTest(fixtures.TestBase):
     __requires__ = ("json_type",)
-    __only_on__ = "mysql", "mariadb"
+    __only_on__ = "tidb"
     __backend__ = True
 
     @testing.requires.reflects_json_type
@@ -762,8 +762,7 @@ class JSONTest(fixtures.TestBase):
 class EnumSetTest(
     fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL
 ):
-    __only_on__ = "mysql", "mariadb"
-    __dialect__ = mysql.dialect()
+    __only_on__ = "tidb"
     __backend__ = True
 
     class SomeEnum(object):

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,6 @@
 alwayscopy=true
 envlist =
     py39
-    py37
-    py36
-    py35
     lint
 
 [testenv]


### PR DESCRIPTION
# New Feature
- TIDB support temporary table after v5.3.0
- TiDB support savepoint after v6.2.0
- TIDB support foreign key after v6.6.0
- Disable `XA` syntax(twophase transaction) because TiDB not support

# Testing
- Reactor `requirements.py`
- Add test cases for transaction
- Remove py36 and py37 from CI because its EOL (I will update ci in next PR)
