### PR TITLE
fix: restrict the version of sqlalchemy between [1.4, 2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(os.path.dirname(__file__), "sqlalchemy_tidb", "__init__.p
 
 readme = os.path.join(os.path.dirname(__file__), "README.md")
 
-dependencies = ["sqlalchemy>=1.4"]
+dependencies = ["sqlalchemy>=1.4,<2"]
 
 setup(
     name="sqlalchemy-tidb",


### PR DESCRIPTION
This repo only works with sqlalchmey==v1.4, but the latest stable version of sqlalchemy is v2, there are some breaking changes between v1.4 and v2, before we adapt the v2, we need to declare this restriction in `setup.py`.

To adapt sqlalchemy==v2, we should create a new branch, it's hard to continue development on the current branch.
